### PR TITLE
feat(ignore): Typos-specific ignores

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,6 +15,7 @@ Configuration is read from the following (in precedence order)
 | Field                  | Argument          | Format | Description |
 |------------------------|-------------------|--------|-------------|
 | files.binary           | --binary          | bool   | Check binary files as text |
+| files.ignore-patterns  |                   | list of strings | Typos-specific ignore globs (gitignore syntax) |
 | files.ignore-hidden    | --hidden          | bool   | Skip hidden files and directories. |
 | files.ignore-files     | --ignore          | bool   | Respect ignore files. |
 | files.ignore-dot       | --ignore-dot      | bool   | Respect .ignore files. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,16 @@ fn run() -> Result<i32, anyhow::Error> {
             .git_ignore(config.files.ignore_vcs())
             .git_exclude(config.files.ignore_vcs())
             .parents(config.files.ignore_parent());
+        if let (Some(root), Some(patterns)) =
+            (config.files.ignore_root(), config.files.ignore_patterns())
+        {
+            let mut overrides = ignore::overrides::OverrideBuilder::new(root);
+            for pattern in patterns {
+                overrides.add(pattern)?;
+            }
+            let overrides = overrides.build()?;
+            walk.overrides(overrides);
+        }
 
         let mut reporter = args.format.reporter();
         let replace_reporter = replace::Replace::new(reporter);


### PR DESCRIPTION
THis is to help with cases like a monorepo with vendored dependencies.
A user might want to search (`.ignore`) them but not hold the code to
the same standards as first-party code.

Fixes #134