### PR TITLE
feat(dict): Override builtin dictionary

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,4 +29,6 @@ Configuration is read from the following (in precedence order)
 | default.identifier-include-digits   | \-   | bool   | Allow identifiers to include digits, in addition to letters. |
 | default.identifier-leading-chars    | \-   | string | Allow identifiers to start with one of these characters. |
 | default.identifier-include-chars    | \-   | string | Allow identifiers to include these characters. |
-| default.locale         | \-                | en, en-us, en-gb, en-ca, en-au   |  |
+| default.locale         | \-                | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
+| default.extend-valid-identifiers    | \-   | list of strings | Identifiers to presume as correct, skipping spell checking.  This extends the list when layering configuration, rather than replacing it. |
+| default.extend-valid-words          | \-   | list of strings | Words to presume as correct, skipping spell checking.  This extends the list when layering configuration, rather than replacing it. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,14 @@ pub trait FileSource {
     fn locale(&self) -> Option<Locale> {
         None
     }
+
+    fn extend_valid_identifiers(&self) -> &[String] {
+        &[]
+    }
+
+    fn extend_valid_words(&self) -> &[String] {
+        &[]
+    }
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -287,6 +295,8 @@ pub struct FileConfig {
     pub identifier_include_digits: Option<bool>,
     pub identifier_include_chars: Option<String>,
     pub locale: Option<Locale>,
+    pub extend_valid_identifiers: Vec<String>,
+    pub extend_valid_words: Vec<String>,
 }
 
 impl FileConfig {
@@ -315,6 +325,10 @@ impl FileConfig {
         if let Some(source) = source.locale() {
             self.locale = Some(source);
         }
+        self.extend_valid_identifiers
+            .extend(source.extend_valid_identifiers().iter().cloned());
+        self.extend_valid_words
+            .extend(source.extend_valid_words().iter().cloned());
     }
 
     pub fn check_filename(&self) -> bool {
@@ -347,6 +361,14 @@ impl FileConfig {
 
     pub fn locale(&self) -> Locale {
         self.locale.unwrap_or_default()
+    }
+
+    pub fn extend_valid_identifiers(&self) -> &[String] {
+        self.extend_valid_identifiers.as_slice()
+    }
+
+    pub fn extend_valid_words(&self) -> &[String] {
+        self.extend_valid_words.as_slice()
     }
 }
 
@@ -381,6 +403,14 @@ impl FileSource for FileConfig {
 
     fn locale(&self) -> Option<Locale> {
         self.locale
+    }
+
+    fn extend_valid_identifiers(&self) -> &[String] {
+        self.extend_valid_identifiers.as_slice()
+    }
+
+    fn extend_valid_words(&self) -> &[String] {
+        self.extend_valid_words.as_slice()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,21 @@ fn run() -> Result<i32, anyhow::Error> {
             .build();
 
         let dictionary = crate::dict::BuiltIn::new(config.default.locale());
+        let mut dictionary = crate::dict::Override::new(dictionary);
+        dictionary.valid_identifiers(
+            config
+                .default
+                .extend_valid_identifiers()
+                .iter()
+                .map(|s| s.as_str()),
+        );
+        dictionary.valid_words(
+            config
+                .default
+                .extend_valid_words()
+                .iter()
+                .map(|s| s.as_str()),
+        );
 
         let mut settings = typos::checks::TyposSettings::new();
         settings


### PR DESCRIPTION
Sometimes you just have to live with a typo or its done intentionally
(like weird company names).  With this commit, a user can now identifier
blessed identifiers and words.

This is ostly what is needed for #9 but sometimes people will have
common typos that they'll want to provide corrections for.