### PR TITLE
feat: Custom dictionary support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
     include:
     - master
 variables:
-  minrust: 1.40.0
+  minrust: 1.42.0
   codecov_token: $(CODECOV_TOKEN_SECRET)
   windows_vm: vs2017-win2016
   mac_vm: macos-10.14

--- a/benches/corrections.rs
+++ b/benches/corrections.rs
@@ -13,7 +13,9 @@ fn correct_word_hit(b: &mut test::Bencher) {
     let input = typos::tokens::Word::new("successs", 0).unwrap();
     assert_eq!(
         corrections.correct_word(input),
-        vec![std::borrow::Cow::Borrowed("successes")]
+        Some(typos::Status::Corrections(vec![
+            std::borrow::Cow::Borrowed("successes")
+        ]))
     );
     b.iter(|| corrections.correct_word(input));
 }
@@ -22,6 +24,6 @@ fn correct_word_hit(b: &mut test::Bencher) {
 fn correct_word_miss(b: &mut test::Bencher) {
     let corrections = typos_cli::dict::BuiltIn::new(Default::default());
     let input = typos::tokens::Word::new("success", 0).unwrap();
-    assert!(corrections.correct_word(input).is_empty());
+    assert!(corrections.correct_word(input).is_none());
     b.iter(|| corrections.correct_word(input));
 }

--- a/crates/typos/src/dict.rs
+++ b/crates/typos/src/dict.rs
@@ -1,7 +1,49 @@
 use std::borrow::Cow;
 
-pub trait Dictionary: Send + Sync {
-    fn correct_ident<'s, 'w>(&'s self, _ident: crate::tokens::Identifier<'w>) -> Vec<Cow<'s, str>>;
+#[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, derive_more::From)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum Status<'c> {
+    Valid,
+    Invalid,
+    Corrections(Vec<Cow<'c, str>>),
+}
 
-    fn correct_word<'s, 'w>(&'s self, word: crate::tokens::Word<'w>) -> Vec<Cow<'s, str>>;
+impl<'c> Status<'c> {
+    pub fn is_invalid(&self) -> bool {
+        matches!(self, Status::Invalid)
+    }
+    pub fn is_valid(&self) -> bool {
+        matches!(self, Status::Valid)
+    }
+    pub fn is_correction(&self) -> bool {
+        matches!(self, Status::Corrections(_))
+    }
+
+    pub fn corrections_mut(&mut self) -> impl Iterator<Item = &mut Cow<'c, str>> {
+        match self {
+            Status::Corrections(corrections) => itertools::Either::Left(corrections.iter_mut()),
+            _ => itertools::Either::Right([].iter_mut()),
+        }
+    }
+
+    pub fn borrow(&self) -> Status<'_> {
+        match self {
+            Status::Corrections(corrections) => {
+                let corrections = corrections
+                    .iter()
+                    .map(|c| Cow::Borrowed(c.as_ref()))
+                    .collect();
+                Status::Corrections(corrections)
+            }
+            _ => self.clone(),
+        }
+    }
+}
+
+pub trait Dictionary: Send + Sync {
+    fn correct_ident<'s, 'w>(&'s self, _ident: crate::tokens::Identifier<'w>)
+        -> Option<Status<'s>>;
+
+    fn correct_word<'s, 'w>(&'s self, word: crate::tokens::Word<'w>) -> Option<Status<'s>>;
 }

--- a/crates/typos/src/tokens.rs
+++ b/crates/typos/src/tokens.rs
@@ -73,7 +73,7 @@ impl ParserBuilder {
             let escaped = regex::escape(&grapheme);
             pattern.push_str(&format!("|{}", escaped));
         }
-        pattern.push_str(r#")"#);
+        pattern.push(')');
     }
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -30,5 +30,5 @@ Configuration is read from the following (in precedence order)
 | default.identifier-leading-chars    | \-   | string | Allow identifiers to start with one of these characters. |
 | default.identifier-include-chars    | \-   | string | Allow identifiers to include these characters. |
 | default.locale         | \-                | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
-| default.extend-valid-identifiers    | \-   | list of strings | Identifiers to presume as correct, skipping spell checking.  This extends the list when layering configuration, rather than replacing it. |
-| default.extend-valid-words          | \-   | list of strings | Words to presume as correct, skipping spell checking.  This extends the list when layering configuration, rather than replacing it. |
+| default.extend-identifiers | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
+| default.extend-words       | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,20 +58,8 @@ fn run() -> Result<i32, anyhow::Error> {
 
         let dictionary = crate::dict::BuiltIn::new(config.default.locale());
         let mut dictionary = crate::dict::Override::new(dictionary);
-        dictionary.valid_identifiers(
-            config
-                .default
-                .extend_valid_identifiers()
-                .iter()
-                .map(|s| s.as_str()),
-        );
-        dictionary.valid_words(
-            config
-                .default
-                .extend_valid_words()
-                .iter()
-                .map(|s| s.as_str()),
-        );
+        dictionary.identifiers(config.default.extend_identifiers());
+        dictionary.words(config.default.extend_words());
 
         let mut settings = typos::checks::TyposSettings::new();
         settings


### PR DESCRIPTION
Switching `valid-*` to just `*` where you map typo to correction, with
support for always-valid and never-valid.

Fixes #9