### PR TITLE
fix(cli): Define an error code policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysexit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26991bb0e6ef939ac9a8d6b57979efa59921928a3aa0334d818fe6e458aa6a9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1101,7 @@ dependencies = [
  "predicates",
  "serde",
  "structopt",
+ "sysexit",
  "toml",
  "typos",
  "typos-dict",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ env_logger = "0.8"
 bstr = "0.2"
 ahash = "0.5.8"
 difflib = "0.4"
+sysexit = "0.2"
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,0 +1,55 @@
+pub struct ExitCode {
+    pub code: sysexit::Code,
+    pub error: Option<anyhow::Error>,
+}
+
+impl ExitCode {
+    pub fn code(code: sysexit::Code) -> Self {
+        Self { code, error: None }
+    }
+
+    pub fn error(mut self, error: anyhow::Error) -> Self {
+        self.error = Some(error);
+        self
+    }
+}
+
+impl From<sysexit::Code> for ExitCode {
+    fn from(code: sysexit::Code) -> Self {
+        Self::code(code)
+    }
+}
+
+pub trait ChainCodeExt {
+    fn error(self) -> ExitCode;
+    fn chain(self, error: anyhow::Error) -> ExitCode;
+}
+
+impl ChainCodeExt for sysexit::Code {
+    fn error(self) -> ExitCode {
+        ExitCode::code(self)
+    }
+    fn chain(self, error: anyhow::Error) -> ExitCode {
+        ExitCode::code(self).error(error)
+    }
+}
+
+pub trait ExitCodeResultErrorExt<T> {
+    fn code(self, code: sysexit::Code) -> Result<T, ExitCode>;
+}
+
+impl<T, E: std::error::Error + Send + Sync + 'static> ExitCodeResultErrorExt<T> for Result<T, E> {
+    fn code(self, code: sysexit::Code) -> Result<T, ExitCode> {
+        self.map_err(|e| ExitCode::code(code).error(e.into()))
+    }
+}
+
+pub trait ExitCodeResultAnyhowExt<T> {
+    fn code(self, code: sysexit::Code) -> Result<T, ExitCode>;
+}
+
+impl<T> ExitCodeResultAnyhowExt<T> for Result<T, anyhow::Error> {
+    fn code(self, code: sysexit::Code) -> Result<T, ExitCode> {
+        self.map_err(|e| ExitCode::code(code).error(e))
+    }
+}


### PR DESCRIPTION
The main goal is to make spelling errors differentiated from other
errors.

Fixes #170