### PR TITLE
Replace instances of scorrect with typos

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,4 +1,4 @@
 [clog]
-repository = "https://github.com/crate-ci/scorrect"
+repository = "https://github.com/crate-ci/typos"
 changelog = "CHANGELOG.md"
 from-latest-tag = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 #### Bug Fixes
 
-*   Ignore numbers as identifiers ([a00831c8](https://github.com/crate-ci/scorrect/commit/a00831c847b7efd81be520ea9b5d02f70555351f))
-*   Improve the organization of --help ([a48a457c](https://github.com/crate-ci/scorrect/commit/a48a457cc3ca817850118e2a2fb8b20fecdd40b8))
+*   Ignore numbers as identifiers ([a00831c8](https://github.com/crate-ci/typos/commit/a00831c847b7efd81be520ea9b5d02f70555351f))
+*   Improve the organization of --help ([a48a457c](https://github.com/crate-ci/typos/commit/a48a457cc3ca817850118e2a2fb8b20fecdd40b8))
 
 #### Features
 
-*   Dump files, identifiers, and words ([ce365ae1](https://github.com/crate-ci/scorrect/commit/ce365ae12e12fddfb6fc42a7f1e5ea71834d6051), closes [#41](https://github.com/crate-ci/scorrect/issues/41))
-*   Give control over allowed identifier characters for leading vs rest ([107308a6](https://github.com/crate-ci/scorrect/commit/107308a655a425eb593bf5e4928572c16e6a9bdd))
+*   Dump files, identifiers, and words ([ce365ae1](https://github.com/crate-ci/typos/commit/ce365ae12e12fddfb6fc42a7f1e5ea71834d6051), closes [#41](https://github.com/crate-ci/typos/issues/41))
+*   Give control over allowed identifier characters for leading vs rest ([107308a6](https://github.com/crate-ci/typos/commit/107308a655a425eb593bf5e4928572c16e6a9bdd))
 
 #### Performance
 
-*   Use standard identifier rules to avoid doing umber checks ([107308a6](https://github.com/crate-ci/scorrect/commit/107308a655a425eb593bf5e4928572c16e6a9bdd))
-*   Only do hex check if digits are in identifiers ([68cd36d0](https://github.com/crate-ci/scorrect/commit/68cd36d0de90226dbc9d31c2ce6d8bf6b69adb5c))
+*   Use standard identifier rules to avoid doing umber checks ([107308a6](https://github.com/crate-ci/typos/commit/107308a655a425eb593bf5e4928572c16e6a9bdd))
+*   Only do hex check if digits are in identifiers ([68cd36d0](https://github.com/crate-ci/typos/commit/68cd36d0de90226dbc9d31c2ce6d8bf6b69adb5c))
 
 
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015 The assert_cli Developers
+Copyright (c) 2019-2021 The typos Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
At some point early on, this project was renamed from "scorrect" to
"typos". Some references to old URLs still exist. This commit corrects
those references.

Unrelatedly, I'm facing an issue building typos as one of the dependencies, `derive_setters`, fails to build after an update (v1.0.58) to its own dependency, `syn` changed its public API: https://github.com/Lymia/derive_setters/pull/3

I attempted to raise an issue or revert PR with https://github.com/dtolnay/syn, as this is a breaking change in a point-release, but the project does not allow non-contributors to create issues or pull requests.

I then attempted to pin `syn` to "1.0.57" in this project's Cargo.toml, however it seems this does not affect what dependency version is selected for sub-dependencies (please, correct me if I'm mistaken.) It seems the only option is to wait for `derive_setters` to merge the previously referenced pull request.

In the meantime, I will attempt to build the project using instructions here: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html