### PR TITLE
feat(config): Per-file type settings 

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -31,3 +31,4 @@ Configuration is read from the following (in precedence order)
 | default.locale         | --locale          | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
 | default.extend-identifiers | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
 | default.extend-words       | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
+| type.<name>.binary         | <varied>      | <varied>   | See `default.` for child keys. |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -31,4 +31,4 @@ Configuration is read from the following (in precedence order)
 | default.locale         | --locale          | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
 | default.extend-identifiers | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
 | default.extend-words       | \-            | table of strings | Corrections for identifiers. When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
-| type.<name>.binary         | <varied>      | <varied>   | See `default.` for child keys. |
+| type.<name>.binary         | <varied>      | <varied>   | See `default.` for child keys.  Run with `--type-list` to see available `<name>`s |

--- a/src/args.rs
+++ b/src/args.rs
@@ -79,9 +79,6 @@ pub(crate) struct Args {
     /// Write the current configuration to file with `-` for stdout
     pub(crate) dump_config: Option<std::path::PathBuf>,
 
-    #[structopt(flatten)]
-    pub(crate) overrides: FileArgs,
-
     #[structopt(
         long,
         possible_values(&Format::variants()),
@@ -177,12 +174,15 @@ impl FileArgs {
 pub(crate) struct ConfigArgs {
     #[structopt(flatten)]
     walk: WalkArgs,
+    #[structopt(flatten)]
+    overrides: FileArgs,
 }
 
 impl ConfigArgs {
     pub fn to_config(&self) -> config::Config {
         config::Config {
             files: self.walk.to_config(),
+            overrides: Some(self.overrides.to_config()),
             ..Default::default()
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -141,7 +141,6 @@ impl FileArgs {
                 locale: self.locale,
                 ..Default::default()
             }),
-            ..Default::default()
         }
     }
 
@@ -241,7 +240,6 @@ impl WalkArgs {
             ignore_vcs: self.ignore_vcs(),
             ignore_global: self.ignore_global(),
             ignore_parent: self.ignore_parent(),
-            ..Default::default()
         }
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -79,6 +79,10 @@ pub(crate) struct Args {
     /// Write the current configuration to file with `-` for stdout
     pub(crate) dump_config: Option<std::path::PathBuf>,
 
+    #[structopt(long, group = "mode")]
+    /// Show all supported file types.
+    pub(crate) type_list: bool,
+
     #[structopt(
         long,
         possible_values(&Format::variants()),

--- a/src/args.rs
+++ b/src/args.rs
@@ -129,7 +129,21 @@ pub(crate) struct FileArgs {
     pub(crate) locale: Option<config::Locale>,
 }
 
-impl config::EngineSource for FileArgs {
+impl FileArgs {
+    pub fn to_config(&self) -> config::EngineConfig {
+        config::EngineConfig {
+            binary: self.binary(),
+            check_filename: self.check_filename(),
+            check_file: self.check_file(),
+            tokenizer: None,
+            dict: Some(config::DictConfig {
+                locale: self.locale,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     fn binary(&self) -> Option<bool> {
         match (self.binary, self.no_binary) {
             (true, false) => Some(true),
@@ -156,16 +170,6 @@ impl config::EngineSource for FileArgs {
             (_, _) => unreachable!("StructOpt should make this impossible"),
         }
     }
-
-    fn dict(&self) -> Option<&dyn config::DictSource> {
-        Some(self)
-    }
-}
-
-impl config::DictSource for FileArgs {
-    fn locale(&self) -> Option<config::Locale> {
-        self.locale
-    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -175,9 +179,12 @@ pub(crate) struct ConfigArgs {
     walk: WalkArgs,
 }
 
-impl config::ConfigSource for ConfigArgs {
-    fn walk(&self) -> Option<&dyn config::WalkSource> {
-        Some(&self.walk)
+impl ConfigArgs {
+    pub fn to_config(&self) -> config::Config {
+        config::Config {
+            files: self.walk.to_config(),
+            ..Default::default()
+        }
     }
 }
 
@@ -221,7 +228,19 @@ pub(crate) struct WalkArgs {
     ignore_vcs: bool,
 }
 
-impl config::WalkSource for WalkArgs {
+impl WalkArgs {
+    pub fn to_config(&self) -> config::Walk {
+        config::Walk {
+            ignore_hidden: self.ignore_hidden(),
+            ignore_files: self.ignore_files(),
+            ignore_dot: self.ignore_dot(),
+            ignore_vcs: self.ignore_vcs(),
+            ignore_global: self.ignore_global(),
+            ignore_parent: self.ignore_parent(),
+            ..Default::default()
+        }
+    }
+
     fn ignore_hidden(&self) -> Option<bool> {
         match (self.hidden, self.no_hidden) {
             (true, false) => Some(false),

--- a/src/args.rs
+++ b/src/args.rs
@@ -182,7 +182,7 @@ impl ConfigArgs {
     pub fn to_config(&self) -> config::Config {
         config::Config {
             files: self.walk.to_config(),
-            overrides: Some(self.overrides.to_config()),
+            overrides: self.overrides.to_config(),
             ..Default::default()
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,10 @@ use std::collections::HashMap;
 pub struct Config {
     pub files: Walk,
     pub default: EngineConfig,
+    #[serde(rename = "type")]
+    pub type_: std::collections::HashMap<kstring::KString, EngineConfig>,
     #[serde(skip)]
-    pub overrides: Option<EngineConfig>,
+    pub overrides: EngineConfig,
 }
 
 impl Config {
@@ -36,7 +38,8 @@ impl Config {
         Self {
             files: Walk::from_defaults(),
             default: EngineConfig::from_defaults(),
-            overrides: None,
+            type_: Default::default(),
+            overrides: EngineConfig::default(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 pub struct Config {
     pub files: Walk,
     pub default: EngineConfig,
+    #[serde(skip)]
+    pub overrides: Option<EngineConfig>,
 }
 
 impl Config {
@@ -34,6 +36,7 @@ impl Config {
         Self {
             files: Walk::from_defaults(),
             default: EngineConfig::from_defaults(),
+            overrides: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
 
     let storage = typos_cli::policy::ConfigStorage::new();
     let mut overrides = config::EngineConfig::default();
-    overrides.update(&args.overrides);
+    overrides.update(&args.overrides.to_config());
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
     engine.set_isolated(args.isolated).set_overrides(overrides);
     if let Some(path) = args.custom_config.as_ref() {
@@ -87,7 +87,7 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
 
     let storage = typos_cli::policy::ConfigStorage::new();
     let mut overrides = config::EngineConfig::default();
-    overrides.update(&args.overrides);
+    overrides.update(&args.overrides.to_config());
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
     engine.set_isolated(args.isolated).set_overrides(overrides);
     if let Some(path) = args.custom_config.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,19 +114,19 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
         engine
             .init_dir(cwd)
             .with_code(proc_exit::Code::CONFIG_ERR)?;
-        let files = engine.files(cwd);
+        let walk_policy = engine.walk(cwd);
 
         let threads = if path.is_file() { 1 } else { args.threads };
         let single_threaded = threads == 1;
 
         let mut walk = ignore::WalkBuilder::new(path);
         walk.threads(args.threads)
-            .hidden(files.ignore_hidden())
-            .ignore(files.ignore_dot())
-            .git_global(files.ignore_global())
-            .git_ignore(files.ignore_vcs())
-            .git_exclude(files.ignore_vcs())
-            .parents(files.ignore_parent());
+            .hidden(walk_policy.ignore_hidden())
+            .ignore(walk_policy.ignore_dot())
+            .git_global(walk_policy.ignore_global())
+            .git_ignore(walk_policy.ignore_vcs())
+            .git_exclude(walk_policy.ignore_vcs())
+            .parents(walk_policy.ignore_parent());
 
         // HACK: Diff doesn't handle mixing content
         let output_reporter = if args.diff {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,17 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
     };
 
     let storage = typos_cli::policy::ConfigStorage::new();
-    let mut overrides = config::EngineConfig::default();
-    overrides.update(&args.overrides.to_config());
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
-    engine.set_isolated(args.isolated).set_overrides(overrides);
+    engine.set_isolated(args.isolated);
+
+    let mut overrides = config::Config::default();
     if let Some(path) = args.custom_config.as_ref() {
         let custom = config::Config::from_file(path).with_code(proc_exit::Code::CONFIG_ERR)?;
-        engine.set_custom_config(custom);
+        overrides.update(&custom);
     }
+    overrides.update(&args.config.to_config());
+    engine.set_overrides(overrides);
+
     let config = engine
         .load_config(cwd)
         .with_code(proc_exit::Code::CONFIG_ERR)?;
@@ -86,14 +89,16 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
     let global_cwd = std::env::current_dir()?;
 
     let storage = typos_cli::policy::ConfigStorage::new();
-    let mut overrides = config::EngineConfig::default();
-    overrides.update(&args.overrides.to_config());
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
-    engine.set_isolated(args.isolated).set_overrides(overrides);
+    engine.set_isolated(args.isolated);
+
+    let mut overrides = config::Config::default();
     if let Some(path) = args.custom_config.as_ref() {
         let custom = config::Config::from_file(path).with_code(proc_exit::Code::CONFIG_ERR)?;
-        engine.set_custom_config(custom);
+        overrides.update(&custom);
     }
+    overrides.update(&args.config.to_config());
+    engine.set_overrides(overrides);
 
     let mut typos_found = false;
     let mut errors_found = false;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -208,14 +208,13 @@ impl<'s> ConfigEngine<'s> {
         let dict = self.dict.intern(dict);
         let tokenizer = self.tokenizer.intern(tokenizer);
 
-        let file = FileConfig {
+        FileConfig {
             check_filenames: check_filename,
             check_files: check_file,
             binary,
             tokenizer,
             dict,
-        };
-        file
+        }
     }
 }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -67,12 +67,20 @@ impl<'s> ConfigEngine<'s> {
         self
     }
 
-    pub fn walk(&mut self, cwd: &std::path::Path) -> &crate::config::Walk {
+    pub fn walk(&self, cwd: &std::path::Path) -> &crate::config::Walk {
         let dir = self
             .configs
             .get(cwd)
             .expect("`init_dir` must be called first");
         self.get_walk(dir)
+    }
+
+    pub fn file_types(&self, cwd: &std::path::Path) -> &[ignore::types::FileTypeDef] {
+        let dir = self
+            .configs
+            .get(cwd)
+            .expect("`init_dir` must be called first");
+        dir.type_matcher.definitions()
     }
 
     pub fn policy(&self, path: &std::path::Path) -> Policy<'_, '_> {


### PR DESCRIPTION
This includes a `--type-list` to know what types are available.  This does not yet include support for adding custom types or error reporting if a non-existent type is referenced.