### PR TITLE
fix(dict)!: Clarify word sizes with Ranges

### DIFF
--- a/crates/typos-dict/codegen/src/main.rs
+++ b/crates/typos-dict/codegen/src/main.rs
@@ -38,8 +38,12 @@ fn generate<W: std::io::Write>(file: &mut W) {
     writeln!(file, "{}", codegenned).unwrap();
     writeln!(file, ";").unwrap();
     writeln!(file).unwrap();
-    writeln!(file, "pub const WORD_MIN: usize = {};", smallest).unwrap();
-    writeln!(file, "pub const WORD_MAX: usize = {};", largest).unwrap();
+    writeln!(
+        file,
+        "pub const WORD_RANGE: std::ops::RangeInclusive<usize> = {}..={};",
+        smallest, largest
+    )
+    .unwrap();
 }
 
 #[derive(Debug, StructOpt)]

--- a/crates/typos-dict/src/dict_codegen.rs
+++ b/crates/typos-dict/src/dict_codegen.rs
@@ -33649,5 +33649,4 @@ pub static WORD_DICTIONARY: phf::Map<unicase::UniCase<&'static str>, &'static st
     ]),
 };
 
-pub const WORD_MIN: usize = 3;
-pub const WORD_MAX: usize = 19;
+pub const WORD_RANGE: std::ops::RangeInclusive<usize> = 3..=19;

--- a/crates/typos-vars/codegen/src/main.rs
+++ b/crates/typos-vars/codegen/src/main.rs
@@ -103,8 +103,12 @@ fn generate_variations<W: std::io::Write>(file: &mut W) {
     writeln!(file, ";").unwrap();
 
     writeln!(file).unwrap();
-    writeln!(file, "pub const WORD_MIN: usize = {};", smallest).unwrap();
-    writeln!(file, "pub const WORD_MAX: usize = {};", largest).unwrap();
+    writeln!(
+        file,
+        "pub const WORD_RANGE: std::ops::RangeInclusive<usize> = {}..={};",
+        smallest, largest
+    )
+    .unwrap();
 
     for (symbol, entry) in entries.iter() {
         if !referenced_symbols.contains(symbol.as_str()) {

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -48,9 +48,7 @@ impl BuiltIn {
 
     // Not using `Status` to avoid the allocations
     fn correct_with_dict(&self, word: &str) -> Option<&'static str> {
-        const WORD_RANGE: std::ops::RangeInclusive<usize> =
-            typos_dict::WORD_MIN..=typos_dict::WORD_MAX;
-        if WORD_RANGE.contains(&word.len()) {
+        if typos_dict::WORD_RANGE.contains(&word.len()) {
             map_lookup(&typos_dict::WORD_DICTIONARY, word)
         } else {
             None
@@ -58,9 +56,7 @@ impl BuiltIn {
     }
 
     fn correct_with_vars(&self, word: &str) -> Option<Status<'static>> {
-        const WORD_RANGE: std::ops::RangeInclusive<usize> =
-            typos_vars::WORD_MIN..=typos_vars::WORD_MAX;
-        if WORD_RANGE.contains(&word.len()) {
+        if typos_vars::WORD_RANGE.contains(&word.len()) {
             map_lookup(&typos_vars::VARS_DICTIONARY, word)
                 .map(|variants| self.select_variant(variants))
         } else {


### PR DESCRIPTION
The code was generated with separate min / max, rather than using a
Range and ensuring the API is used correctly.