### PR TITLE
fix(cli): Clarify API stabiliy

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -380,7 +380,7 @@ impl FileChecker for FoundFiles {
     }
 }
 
-pub fn read_file(
+fn read_file(
     path: &std::path::Path,
     reporter: &dyn report::Report,
 ) -> Result<(Vec<u8>, content_inspector::ContentType), std::io::Error> {
@@ -418,7 +418,7 @@ pub fn read_file(
     Ok((buffer, content_type))
 }
 
-pub fn write_file(
+fn write_file(
     path: &std::path::Path,
     content_type: content_inspector::ContentType,
     buffer: Vec<u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
+/// `typos_cli`'s API is unstable.  Open an issue for starting a discussion on getting a subset
+/// stabilized.
+
+#[doc(hidden)]
 pub mod config;
+#[doc(hidden)]
 pub mod dict;
+#[doc(hidden)]
 pub mod file;
+#[doc(hidden)]
 pub mod policy;
+#[doc(hidden)]
 pub mod report;


### PR DESCRIPTION
For now, I'm just punting on `typos_cli`s API.

Fixes #171