### PR TITLE
fix(cli): Discover config in parent dirs 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ impl Config {
         let config = if let Some(path) =
             find_project_file(cwd, &["typos.toml", "_typos.toml", ".typos.toml"])
         {
+            log::debug!("Loading {}", path.display());
             Some(Self::from_file(&path)?)
         } else {
             None

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -123,8 +123,11 @@ impl<'s> ConfigEngine<'s> {
         let mut config = crate::config::Config::default();
 
         if !self.isolated {
-            if let Some(derived) = crate::config::Config::from_dir(cwd)? {
-                config.update(&derived);
+            for ancestor in cwd.ancestors() {
+                if let Some(derived) = crate::config::Config::from_dir(ancestor)? {
+                    config.update(&derived);
+                    break;
+                }
             }
         }
         if let Some(overrides) = self.overrides.as_ref() {


### PR DESCRIPTION
My only guess is that in a76ddd4, I lost track of different parts of my
change and never re-implemented this logic.