### PR TITLE
fix(cli): Display shortened paths to users

### DIFF
--- a/src/bin/typos-cli/main.rs
+++ b/src/bin/typos-cli/main.rs
@@ -65,11 +65,6 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
     let global_cwd = std::env::current_dir()?;
 
     let path = &args.path[0];
-    let path = if path == std::path::Path::new("-") {
-        path.to_owned()
-    } else {
-        path.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?
-    };
     let cwd = if path == std::path::Path::new("-") {
         global_cwd.as_path()
     } else if path.is_file() {
@@ -77,6 +72,7 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
     } else {
         path.as_path()
     };
+    let cwd = cwd.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?;
 
     let storage = typos_cli::policy::ConfigStorage::new();
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
@@ -92,7 +88,7 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
     engine.set_overrides(overrides);
 
     let config = engine
-        .load_config(cwd)
+        .load_config(&cwd)
         .with_code(proc_exit::Code::CONFIG_ERR)?;
 
     let mut defaulted_config = typos_cli::config::Config::from_defaults();
@@ -111,11 +107,6 @@ fn run_type_list(args: &args::Args) -> proc_exit::ExitResult {
     let global_cwd = std::env::current_dir()?;
 
     let path = &args.path[0];
-    let path = if path == std::path::Path::new("-") {
-        path.to_owned()
-    } else {
-        path.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?
-    };
     let cwd = if path == std::path::Path::new("-") {
         global_cwd.as_path()
     } else if path.is_file() {
@@ -123,6 +114,7 @@ fn run_type_list(args: &args::Args) -> proc_exit::ExitResult {
     } else {
         path.as_path()
     };
+    let cwd = cwd.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?;
 
     let storage = typos_cli::policy::ConfigStorage::new();
     let mut engine = typos_cli::policy::ConfigEngine::new(&storage);
@@ -138,9 +130,9 @@ fn run_type_list(args: &args::Args) -> proc_exit::ExitResult {
     engine.set_overrides(overrides);
 
     engine
-        .init_dir(cwd)
+        .init_dir(&cwd)
         .with_code(proc_exit::Code::CONFIG_ERR)?;
-    let definitions = engine.file_types(cwd);
+    let definitions = engine.file_types(&cwd);
 
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
@@ -179,11 +171,6 @@ fn run_checks(
     let mut typos_found = false;
     let mut errors_found = false;
     for path in args.path.iter() {
-        let path = if path == std::path::Path::new("-") {
-            path.to_owned()
-        } else {
-            path.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?
-        };
         let cwd = if path == std::path::Path::new("-") {
             global_cwd.as_path()
         } else if path.is_file() {
@@ -191,11 +178,12 @@ fn run_checks(
         } else {
             path.as_path()
         };
+        let cwd = cwd.canonicalize().with_code(proc_exit::Code::USAGE_ERR)?;
 
         engine
-            .init_dir(cwd)
+            .init_dir(&cwd)
             .with_code(proc_exit::Code::CONFIG_ERR)?;
-        let walk_policy = engine.walk(cwd);
+        let walk_policy = engine.walk(&cwd);
 
         let threads = if path.is_file() { 1 } else { args.threads };
         let single_threaded = threads == 1;

--- a/src/file.rs
+++ b/src/file.rs
@@ -598,12 +598,14 @@ fn walk_entry(
     };
     if entry.file_type().map(|t| t.is_file()).unwrap_or(true) {
         let explicit = entry.depth() == 0;
-        let path = if entry.is_stdin() {
-            std::path::Path::new("-")
+        let (path, lookup_path) = if entry.is_stdin() {
+            let path = std::path::Path::new("-");
+            (path, path.to_owned())
         } else {
-            entry.path()
+            let path = entry.path();
+            (path, path.canonicalize()?)
         };
-        let policy = engine.policy(path);
+        let policy = engine.policy(&lookup_path);
         checks.check_file(path, explicit, &policy, reporter)?;
     }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -68,6 +68,7 @@ impl<'s> ConfigEngine<'s> {
     }
 
     pub fn walk(&self, cwd: &std::path::Path) -> &crate::config::Walk {
+        debug_assert!(cwd.is_absolute(), "{} is not absolute", cwd.display());
         let dir = self
             .configs
             .get(cwd)
@@ -76,6 +77,7 @@ impl<'s> ConfigEngine<'s> {
     }
 
     pub fn file_types(&self, cwd: &std::path::Path) -> &[ignore::types::FileTypeDef] {
+        debug_assert!(cwd.is_absolute(), "{} is not absolute", cwd.display());
         let dir = self
             .configs
             .get(cwd)
@@ -84,6 +86,7 @@ impl<'s> ConfigEngine<'s> {
     }
 
     pub fn policy(&self, path: &std::path::Path) -> Policy<'_, '_> {
+        debug_assert!(path.is_absolute(), "{} is not absolute", path.display());
         let dir = self.get_dir(path).expect("`walk()` should be called first");
         let file_config = dir.get_file_config(path);
         Policy {
@@ -120,6 +123,7 @@ impl<'s> ConfigEngine<'s> {
         &self,
         cwd: &std::path::Path,
     ) -> Result<crate::config::Config, anyhow::Error> {
+        debug_assert!(cwd.is_absolute(), "{} is not absolute", cwd.display());
         let mut config = crate::config::Config::default();
 
         if !self.isolated {
@@ -157,6 +161,7 @@ impl<'s> ConfigEngine<'s> {
     }
 
     pub fn init_dir(&mut self, cwd: &std::path::Path) -> Result<(), anyhow::Error> {
+        debug_assert!(cwd.is_absolute(), "{} is not absolute", cwd.display());
         if self.configs.contains_key(cwd) {
             return Ok(());
         }
@@ -380,7 +385,7 @@ mod test {
         };
         engine.set_overrides(config);
 
-        let cwd = std::path::Path::new(".");
+        let cwd = std::path::Path::new(".").canonicalize().unwrap();
         let loaded = engine.load_config(&cwd).unwrap();
         assert_eq!(loaded.default.binary, Some(false));
         assert_eq!(loaded.default.check_filename, Some(true));
@@ -414,7 +419,7 @@ mod test {
         };
         engine.set_overrides(config);
 
-        let cwd = std::path::Path::new(".");
+        let cwd = std::path::Path::new(".").canonicalize().unwrap();
         let result = engine.init_dir(&cwd);
         assert!(result.is_err());
     }
@@ -428,7 +433,7 @@ mod test {
         let config = crate::config::Config::default();
         engine.set_overrides(config);
 
-        let cwd = std::path::Path::new(".");
+        let cwd = std::path::Path::new(".").canonicalize().unwrap();
         engine.init_dir(&cwd).unwrap();
         let policy = engine.policy(&cwd.join("Cargo.toml"));
         assert!(!policy.binary);
@@ -460,7 +465,7 @@ mod test {
         };
         engine.set_overrides(config);
 
-        let cwd = std::path::Path::new(".");
+        let cwd = std::path::Path::new(".").canonicalize().unwrap();
         engine.init_dir(&cwd).unwrap();
         let policy = engine.policy(&cwd.join("Cargo.toml"));
         assert!(policy.binary);
@@ -492,7 +497,7 @@ mod test {
         };
         engine.set_overrides(config);
 
-        let cwd = std::path::Path::new(".");
+        let cwd = std::path::Path::new(".").canonicalize().unwrap();
         engine.init_dir(&cwd).unwrap();
         let policy = engine.policy(&cwd.join("Cargo.toml"));
         assert!(policy.binary);


### PR DESCRIPTION
Before, we always displayed absolute paths and now we'll display
relative ones.

The main issue was loading the config correctly.  We just have to
cannonicalize whenever doing so.