### PR TITLE
perf(dict): Bypass vars when possible

### DIFF
--- a/crates/typos-vars/codegen/src/main.rs
+++ b/crates/typos-vars/codegen/src/main.rs
@@ -78,6 +78,7 @@ fn generate_variations<W: std::io::Write>(file: &mut W) {
 
     let mut smallest = usize::MAX;
     let mut largest = usize::MIN;
+    let mut no_invalid = true;
 
     writeln!(
         file,
@@ -97,6 +98,8 @@ fn generate_variations<W: std::io::Write>(file: &mut W) {
         builder.entry(unicase::UniCase::new(word), &value);
         smallest = std::cmp::min(smallest, word.len());
         largest = std::cmp::max(largest, word.len());
+
+        no_invalid &= !is_always_invalid(data);
     }
     let codegenned = builder.build();
     writeln!(file, "{}", codegenned).unwrap();
@@ -110,6 +113,10 @@ fn generate_variations<W: std::io::Write>(file: &mut W) {
     )
     .unwrap();
 
+    writeln!(file).unwrap();
+    writeln!(file, "pub const NO_INVALID: bool = {:?};", no_invalid,).unwrap();
+
+    writeln!(file).unwrap();
     for (symbol, entry) in entries.iter() {
         if !referenced_symbols.contains(symbol.as_str()) {
             continue;
@@ -150,6 +157,15 @@ fn is_always_valid(data: &[(&str, varcon::CategorySet)]) -> bool {
     let valid_categories = valid_categories();
     for (_symbol, set) in data.iter() {
         if *set == valid_categories {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_always_invalid(data: &[(&str, varcon::CategorySet)]) -> bool {
+    for (_symbol, set) in data.iter() {
+        if set.is_empty() {
             return true;
         }
     }

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -48,8 +48,10 @@ impl BuiltIn {
             .for_each(|mut s| case_correct(&mut s, word_token.case()));
         Some(corrections)
     }
+}
 
-    #[cfg(feature = "dict")]
+#[cfg(feature = "dict")]
+impl BuiltIn {
     // Not using `Status` to avoid the allocations
     fn correct_with_dict(&self, word: &str) -> Option<&'static [&'static str]> {
         if typos_dict::WORD_RANGE.contains(&word.len()) {
@@ -58,13 +60,17 @@ impl BuiltIn {
             None
         }
     }
+}
 
-    #[cfg(not(feature = "dict"))]
+#[cfg(not(feature = "dict"))]
+impl BuiltIn {
     fn correct_with_dict(&self, _word: &str) -> Option<&'static [&'static str]> {
         None
     }
+}
 
-    #[cfg(feature = "vars")]
+#[cfg(feature = "vars")]
+impl BuiltIn {
     fn chain_with_vars(&self, corrections: &'static [&'static str]) -> Status<'static> {
         let mut chained: Vec<_> = corrections
             .iter()
@@ -84,12 +90,6 @@ impl BuiltIn {
         Status::Corrections(chained)
     }
 
-    #[cfg(not(feature = "vars"))]
-    fn chain_with_vars(&self, corrections: &'static [&'static str]) -> Status<'static> {
-        Status::Corrections(corrections.iter().map(|c| Cow::Borrowed(*c)).collect())
-    }
-
-    #[cfg(feature = "vars")]
     fn correct_with_vars(&self, word: &str) -> Option<Status<'static>> {
         if typos_vars::WORD_RANGE.contains(&word.len()) {
             map_lookup(&typos_vars::VARS_DICTIONARY, word)
@@ -99,12 +99,6 @@ impl BuiltIn {
         }
     }
 
-    #[cfg(not(feature = "vars"))]
-    fn correct_with_vars(&self, _word: &str) -> Option<Status<'static>> {
-        None
-    }
-
-    #[cfg(feature = "vars")]
     fn select_variant(
         &self,
         vars: &'static [(u8, &'static typos_vars::VariantsMap)],
@@ -145,6 +139,17 @@ impl BuiltIn {
                 Status::Valid
             }
         }
+    }
+}
+
+#[cfg(not(feature = "vars"))]
+impl BuiltIn {
+    fn chain_with_vars(&self, corrections: &'static [&'static str]) -> Status<'static> {
+        Status::Corrections(corrections.iter().map(|c| Cow::Borrowed(*c)).collect())
+    }
+
+    fn correct_with_vars(&self, _word: &str) -> Option<Status<'static>> {
+        None
     }
 }
 


### PR DESCRIPTION
Variant support slows us down by 10-50$.  I assume most people will run
with `en` and so most of this overhead is to waste.  So instead of
merging vars with dict, let's instead get a quick win by just skipping
vars when we don't need to.  If the assumptions behind this change over
time or if there is need for speeding up a specific locale, we can
re-address this.

Before:
```
check_file/Typos/code   time:   [35.860 us 36.021 us 36.187 us]
                        thrpt:  [8.0117 MiB/s 8.0486 MiB/s 8.0846 MiB/s]
check_file/Typos/corpus time:   [26.966 ms 27.215 ms 27.521 ms]
                        thrpt:  [21.127 MiB/s 21.365 MiB/s 21.562 MiB/s]
```
After:
```
check_file/Typos/code   time:   [33.837 us 33.928 us 34.031 us]
                        thrpt:  [8.5191 MiB/s 8.5452 MiB/s 8.5680 MiB/s]
check_file/Typos/corpus time:   [17.521 ms 17.620 ms 17.730 ms]
                        thrpt:  [32.794 MiB/s 32.999 MiB/s 33.184 MiB/s]
```

This puts us inline with `--no-default-features --features dict`

Fixes #253