### PR TITLE
fix: Count lines correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Bug Fixes
+
+- Line numbers were off by `1 + <number of prior typos>`
+
 ## [1.0.0] - 2021-05-25
 
 ## [0.4.0] - 2021-05-21

--- a/src/file.rs
+++ b/src/file.rs
@@ -502,7 +502,7 @@ impl AccumulateLineNum {
     fn line_num(&mut self, buffer: &[u8], byte_offset: usize) -> usize {
         assert!(self.last_offset <= byte_offset);
         let slice = &buffer[self.last_offset..byte_offset];
-        let newlines = slice.lines().count();
+        let newlines = slice.find_iter(b"\n").count();
         let line_num = self.line_num + newlines;
         self.line_num = line_num;
         self.last_offset = byte_offset;
@@ -673,6 +673,31 @@ mod test {
             vec![(4, "foo", "happy"), (8, "foo", "world")],
         );
         assert_eq!(actual, "foo happy world");
+    }
+
+    #[test]
+    fn test_line_count_first() {
+        let mut accum_line_num = AccumulateLineNum::new();
+        let line_num = accum_line_num.line_num(b"hello world", 6);
+        assert_eq!(line_num, 1);
+    }
+
+    #[test]
+    fn test_line_count_second() {
+        let mut accum_line_num = AccumulateLineNum::new();
+        let line_num = accum_line_num.line_num(b"1\n2\n3", 2);
+        assert_eq!(line_num, 2);
+    }
+
+    #[test]
+    fn test_line_count_multiple() {
+        let mut accum_line_num = AccumulateLineNum::new();
+        let line_num = accum_line_num.line_num(b"1\n2\n3", 0);
+        assert_eq!(line_num, 1);
+        let line_num = accum_line_num.line_num(b"1\n2\n3", 2);
+        assert_eq!(line_num, 2);
+        let line_num = accum_line_num.line_num(b"1\n2\n3", 4);
+        assert_eq!(line_num, 3);
     }
 
     #[test]


### PR DESCRIPTION
I didn't count on how `buffer.lines().count()` would handle different
corner cases, like slices with no `\n`, slices with trailing `\n`, etc.

Fixes #259