### PR TITLE
Adding github action to use typos to check spelling

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,25 @@
+name: Test GitHub Action
+on: [pull_request]
+
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+
+    - name: Prepare file with mistakes.
+      run: echo "The quick brown foxx jumped over the slepy dog." > file.txt 
+    - name: Test force pass with mistakes
+      continue-on-error: true
+      uses: ./
+      with: 
+        files: ./file.txt
+
+    - name: Prepare file with no mistakes.
+      run: echo "The quick brown fox jumped over the sleepy dog." > file.txt 
+    - name: Test force pass with no mistakes
+      uses: ./
+      with: 
+        files: ./file.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
   {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly=1},
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/{{tag_name}}...HEAD", exactly=1},
+  {file="docker/Dockerfile", search="ARG VERSION=.*", replace="ARG VERSION={{version}}", min=1},
 ]
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04
+ARG VERSION=1.0.3
+ENV VERSION=${VERSION}
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/crate-ci/typos/releases/download/v${VERSION}/typos-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+    tar -xzvf typos-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+    mv typos /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/typos"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE)
 
 - [Installation](#install)
 - [Getting Started](#getting-started)
+  - [False Positives](#false-positives)
+  - [Integrations](#integrations)
+    - [GitHub Action](docs/github-action.md)
+  - [Debugging](#debugging)
 - [Reference](docs/reference.md)
 - [Comparison with other spell checkers](docs/comparison.md)
 - [Benchmarks](benchsuite/runs)
@@ -36,7 +40,6 @@ Or use rust to install:
 ```bash
 cargo install typos-cli
 ```
-
 ## Getting Started
 
 Most commonly, you'll either want to see what typos are available with
@@ -82,7 +85,7 @@ extend-exclude = ["localized/*.po"]
 
 ### Integrations
 
-`typos` provides several building blocks for custom integrations
+`typos` provides several building blocks for custom native integrations
 - `-` reads from `stdin`, `--write-changes` will be written to `stdout`
 - `--diff` to provide a diff
 - `--format json` to get jsonlines with exit code 0 on no errors, code 2 on typos, anything else is an error.
@@ -96,6 +99,9 @@ typos dir/file --diff
 # Fully programmatic control
 typos dir/file --format json
 ```
+
+In addition, see the documentation on [GitHub Actions](docs/github-actions.md),
+another integration.
 
 ### Debugging
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,33 @@
+name: "typos-action"
+author: "Vanessa Sochat"
+description: "Run typos to check spelling in GitHub actions"
+
+inputs:
+  files:
+    description: "Files or patterns to check"
+    required: false
+
+  extend_identifiers:
+    description: "Comma separated list of extend identifiers, like someone's name"
+    required: false
+
+  extend_words:
+    description: "Comma separated list of extend words."
+    required: false
+
+  isolated:
+    description: "Ignore implicit configuration files"
+    required: false
+    default: false
+
+  config:
+    description: "Use a custom config file."
+    required: false
+
+runs:
+  using: "docker"
+  image: "docker/Dockerfile"
+
+branding:
+  icon: "link"
+  color: "blue"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+ARG VERSION=1.0.3
+ENV VERSION=${VERSION}
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/crate-ci/typos/releases/download/v${VERSION}/typos-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+    tar -xzvf typos-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+    mv typos /usr/local/bin
+COPY entrypoint.sh /entrypoint.sh
+WORKDIR /github/workspace
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+printf "Found files in workspace:\n"
+ls
+
+printf "\nLooking for typos installed...\n"
+which typos
+
+COMMAND="typos"
+
+# Show the _typos.toml file
+if [ -f "_typos.toml" ]; then
+    echo "_typos.toml:"
+    cat _typos.toml
+    echo
+fi
+
+# Ignore implicit configuration files
+if [ "${INPUT_ISOLATED}" == "true" ]; then
+    COMMAND="${COMMAND} --isolated"
+fi
+
+
+# Use a custom configuration file
+if [ ! -z "${INPUT_CONFIG}" ]; then
+
+    # It must exist
+    if [ ! -f "${INPUT_CONFIG}" ]; then
+        printf "${INPUT_CONFIG} does not exist.\n"
+        exit 1;
+    else
+        # Show the custom config to the user
+        printf "Custom config:\n"
+        cat "${INPUT_CONFIG}"    
+        echo
+    fi
+    COMMAND="${COMMAND} --config ${INPUT_CONFIG}"
+fi
+
+# Files are technically optional
+if [ ! -z "${INPUT_FILES}" ]; then
+    COMMAND="${COMMAND} ${INPUT_FILES}"
+fi
+
+echo "Command: "
+echo "${COMMAND}"
+echo
+
+${COMMAND}
+retval=$?
+
+if [[ "${retval}" -eq 0 ]]; then
+   printf "No spelling mistakes found! 🎉️\n"
+else
+   printf "Spelling mistakes found! 😱️\n"
+   exit $retval;
+fi

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,48 @@
+# GitHub Action
+
+If you want an easy way to test your repository spelling (or a subset of files)
+you can use the Typos Action! It is served from this repository, and can
+easily be used as follows:
+
+```yaml
+name: Test GitHub Action
+on: [pull_request]
+
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+
+    - name: Check spelling of file.txt
+      uses: crate-ci/typos@main
+      with: 
+        files: ./file.txt
+
+    - name: Use custom config file
+      uses: crate-ci/typos@main
+      with: 
+        files: ./file.txt
+        config: ./myconfig.toml
+
+    - name: Ignore implicit configuration file
+      uses: crate-ci/typos@main
+      with: 
+        files: ./file.txt
+        isolated: true
+```
+
+**Important** for any of the examples above, make sure that you choose
+a release or commit as a version, and not a branch (which is a moving target).
+Also make sure when referencing relative file paths to use `./` (e.g., `./file.txt` instead of
+`file.txt`.
+
+## Variables
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| files| Files or patterns to check | false | If not defined, entire repository is checked |
+| isolated | Ignore implicit configuration files | false | false|
+| config | Use a custom config file (must exist) | false | not set |


### PR DESCRIPTION
Hi @epage!

I really love this little tool, and wanted an easy way to add it to CI for some of my repos to check my spelling. I thought it might be useful to have a GitHub action, so this pull request is adding one here! The user will be able to add a step to a GitHub Workflow that looks like:

```yaml
    - name: Test extend identifiers
      uses: crate-ci/typos@<branch, commit, or relase>
      with: 
        files: ./file.txt
        force_pass: false
        extend_words: "word1,word2"
        extend_identifiers: "IdentifierToAdd,Secondidentifier"
```

And spell check some portion of their repository.  I've added a documentation page, and a GitHub Workflow to both demonstrate usage and test the action. Some points for discussion!

1. If you absolutely don't want it served alongside the code here, I'd be happy to put in its own repository. I just wanted to bring it here first because it's logical that the two will be synced.
2. The action builds directly from the Dockerfile added here, which installs the latest release of typos. This would need to be updated alongside releases. Another option would be to provide a docker image directly, which has the benefit of not needing to wait to build, but then you would need a separate release cycle for the container.  Building from source would probably take much longer, so I chose this middle of the road approach to build but use the release binary.
3. If you have preference for a different color or icon, or interface (what is printed) for the action, we can discuss that too!


Signed-off-by: vsoch <vsoch@users.noreply.github.com>