### PR TITLE
Fix example in github-action.md

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -17,18 +17,18 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check spelling of file.txt
-      uses: crate-ci/typos@main
+      uses: crate-ci/typos@master
       with: 
         files: ./file.txt
 
     - name: Use custom config file
-      uses: crate-ci/typos@main
+      uses: crate-ci/typos@master
       with: 
         files: ./file.txt
         config: ./myconfig.toml
 
     - name: Ignore implicit configuration file
-      uses: crate-ci/typos@main
+      uses: crate-ci/typos@master
       with: 
         files: ./file.txt
         isolated: true


### PR DESCRIPTION
The repository of crate-ci/typos does not have a "main" branch, "master" is used instead.