### PR TITLE
fix(cli): Don't crash on races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Bug Fixes
+
+- Fix a crash from hitting a race condition
+
 ## [1.0.8] - 2021-06-15
 
 ## [1.0.7] - 2021-06-15

--- a/src/bin/typos-cli/report.rs
+++ b/src/bin/typos-cli/report.rs
@@ -59,21 +59,12 @@ impl<'r> MessageStatus<'r> {
 
 impl<'r> Report for MessageStatus<'r> {
     fn report(&self, msg: Message) -> Result<(), std::io::Error> {
-        let _ = self.typos_found.compare_exchange(
-            false,
-            msg.is_correction(),
-            atomic::Ordering::Relaxed,
-            atomic::Ordering::Relaxed,
-        );
-        let _ = self
-            .errors_found
-            .compare_exchange(
-                false,
-                msg.is_error(),
-                atomic::Ordering::Relaxed,
-                atomic::Ordering::Relaxed,
-            )
-            .unwrap();
+        if msg.is_correction() {
+            self.typos_found.store(true, atomic::Ordering::Relaxed);
+        }
+        if msg.is_error() {
+            self.errors_found.store(true, atomic::Ordering::Relaxed);
+        }
         self.reporter.report(msg)
     }
 }


### PR DESCRIPTION
I misused `compare_exchange` when I didn't even really need it.

Fixes #284