### PR TITLE
refactor: Swap Iterators for pushgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pushgen"
+version = "0.0.1"
+source = "git+https://github.com/AndWass/pushgen.git#bdaeafd3b5e6689b9f40dd4308581770c587d003"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1456,7 @@ dependencies = [
  "log",
  "nom",
  "once_cell",
+ "pushgen",
  "serde",
  "simdutf8",
  "thiserror",
@@ -1484,6 +1493,7 @@ dependencies = [
  "phf 0.8.0",
  "predicates",
  "proc-exit",
+ "pushgen",
  "serde",
  "serde_json",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ unicode-segmentation = "1.6.0"
 derive_more = "0.99.11"
 derive_setters = "0.1"
 itertools = "0.10"
+pushgen = { git = "https://github.com/AndWass/pushgen.git" }
 serde_json = "1.0"
 encoding = "0.2"
 kstring = "1.0"

--- a/benches/tokenize.rs
+++ b/benches/tokenize.rs
@@ -1,6 +1,7 @@
 mod data;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use pushgen::GeneratorExt;
 
 fn bench_parse_str(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse_str");

--- a/crates/typos/Cargo.toml
+++ b/crates/typos/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 simdutf8 = "0.1.1"
 itertools = "0.10"
+pushgen = { git = "https://github.com/AndWass/pushgen.git" }
 log = "0.4"
 unicode-segmentation = "1.7.1"
 bstr = "0.2"

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,9 @@
-use bstr::ByteSlice;
-use encoding::Encoding;
 use std::io::Read;
 use std::io::Write;
+
+use bstr::ByteSlice;
+use encoding::Encoding;
+use pushgen::GeneratorExt;
 
 use crate::report;
 


### PR DESCRIPTION
Our iterator/generator sources are:
- `Utf8Chunks.flat_map(parse_str).flat_map(split)`
- `parse_str.flat_map(split)`

Everything else just chains off of those.  Out of laziness, I did not
port `split` to pushgen because that is more work and I wanted to prove
out pushgen first.

The downside to this is that pushgen is in its very early stages.

See #310 for more information on switching to `Iterator::try_for_each`.