### PR TITLE
fix(parser): Handle c-escape/printf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Bug Fixes
+
+- Reduce false-positives by ignoring words following possible c-escape sequences or printf patterns.
+
 ## [1.1.2] - 2021-07-30
 
 #### Bug Fixes


### PR DESCRIPTION
Since our goal is 100% confidence in the results, its better to not
check words than to correct the wrong words.

With that in mind, we'll ignore words after what might be c-escape
sequences (`\nfoo`) or printf substitutions (`%dfoo`).

Fixes #3