### PR TITLE
Fix multiple escape sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,9 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trycmd"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b15571a9c85f2dc93e93907813b8b82583a60c1ee738ef5fa5123f4c96863b5"
+checksum = "2d034538089e906ac14df42c19aae52a55aa1014102d6895d9748080e043cc48"
 dependencies = [
  "concolor-control",
  "difflib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ maplit = "1.0"
 
 [dev-dependencies]
 assert_fs = "1.0"
-trycmd = "0.4"
+trycmd = "0.5.1"
 criterion = "0.3"
 
 [profile.dev]

--- a/tests/cmd/double-escaped.stdin
+++ b/tests/cmd/double-escaped.stdin
@@ -1,0 +1,2 @@
+\n\n
+Destory

--- a/tests/cmd/double-escaped.stdout
+++ b/tests/cmd/double-escaped.stdout
@@ -1,0 +1,2 @@
+\n\n
+Destroy

--- a/tests/cmd/double-escaped.toml
+++ b/tests/cmd/double-escaped.toml
@@ -1,0 +1,3 @@
+bin.name = "typos"
+args = "--write-changes -"
+status.code = 0


### PR DESCRIPTION
If escape sequences follow straight after each other, there is no
delimiter in-between.
In such a case, parsing previously stopped and did not find any
typos further in the file.

Also change the c-escape parser to take either \\+\<single char> or
\\+\<char sequence delimited by space or similar>.

Also update trycmd, so failures actually show up in CI.