### PR TITLE
fix(config): Ensure type-specific settings work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
  "bytes",
  "memchr",
@@ -1478,6 +1478,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b80ac5e1b91e3378c63dab121962472b5ca20cf9ab1975e3d588548717807a8"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring",
+ "serde",
+]
+
+[[package]]
 name = "trycmd"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1507,7 @@ dependencies = [
  "serde",
  "shlex",
  "tempfile",
- "toml_edit",
+ "toml_edit 0.10.1",
  "wait-timeout",
  "walkdir",
  "yansi",
@@ -1553,7 +1566,7 @@ dependencies = [
  "proc-exit",
  "serde",
  "serde_json",
- "toml",
+ "toml_edit 0.13.0",
  "trycmd",
  "typed-arena",
  "typos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ clap = "3.0"
 clap-verbosity-flag = "0.4"
 ignore = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
+toml_edit = { version = "0.13.0", features = ["easy"] }
 log = "0.4"
 env_logger = { version = "0.9", default-features = false, features = ["termcolor"] }
 atty = "0.2.14"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ teh = "teh"
 For cases like localized content, you can disable spell checking of file contents while still checking the file name:
 ```toml
 [type.po]
-extend-globs = ["*.po"]
+extend-glob = ["*.po"]
 check-file = false
 ```
 (run `typos --type-list` to see configured file types)

--- a/src/bin/typos-cli/main.rs
+++ b/src/bin/typos-cli/main.rs
@@ -85,7 +85,8 @@ fn run_dump_config(args: &args::Args, output_path: &std::path::Path) -> proc_exi
 
     let mut defaulted_config = typos_cli::config::Config::from_defaults();
     defaulted_config.update(&config);
-    let output = toml::to_string_pretty(&defaulted_config).with_code(proc_exit::Code::FAILURE)?;
+    let output =
+        toml_edit::easy::to_string_pretty(&defaulted_config).with_code(proc_exit::Code::FAILURE)?;
     if output_path == std::path::Path::new("-") {
         std::io::stdout().write_all(output.as_bytes())?;
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ impl Config {
     }
 
     pub fn from_toml(data: &str) -> Result<Self, anyhow::Error> {
-        let content = toml::from_str(data)?;
+        let content = toml_edit::easy::from_str(data)?;
         Ok(content)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -563,4 +563,26 @@ mod test {
         let expected: Vec<kstring::KString> = vec!["*.foo".into(), "*.bar".into()];
         assert_eq!(actual.extend_glob, expected);
     }
+
+    #[test]
+    fn parse_extend_globs() {
+        let input = r#"[type.po]
+extend-glob = ["*.po"]
+"#;
+        let mut expected = Config::default();
+        expected.type_.patterns.insert(
+            "po".into(),
+            GlobEngineConfig {
+                extend_glob: vec!["*.po".into()],
+                engine: EngineConfig {
+                    tokenizer: Some(TokenizerConfig::default()),
+                    dict: Some(DictConfig::default()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let actual = Config::from_toml(input).unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,7 +235,7 @@ impl TypeEngineConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+//#[serde(deny_unknown_fields)]  // Doesn't work with `flatten`
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct GlobEngineConfig {
@@ -252,7 +252,7 @@ impl GlobEngineConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+//#[serde(deny_unknown_fields)]  // Doesn't work with `flatten`
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct EngineConfig {
@@ -575,6 +575,7 @@ mod test {
     fn parse_extend_globs() {
         let input = r#"[type.po]
 extend-glob = ["*.po"]
+check-file = true
 "#;
         let mut expected = Config::default();
         expected.type_.patterns.insert(
@@ -584,6 +585,7 @@ extend-glob = ["*.po"]
                 engine: EngineConfig {
                     tokenizer: Some(TokenizerConfig::default()),
                     dict: Some(DictConfig::default()),
+                    check_file: Some(true),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -588,7 +588,6 @@ check-file = true
                     check_file: Some(true),
                     ..Default::default()
                 },
-                ..Default::default()
             },
         );
         let actual = Config::from_toml(input).unwrap();
@@ -621,7 +620,6 @@ inout = "inout"
                     }),
                     ..Default::default()
                 },
-                ..Default::default()
             },
         );
         let actual = Config::from_toml(input).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -594,4 +594,37 @@ check-file = true
         let actual = Config::from_toml(input).unwrap();
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn parse_extend_words() {
+        let input = r#"[type.shaders]
+extend-glob = [
+  '*.shader',
+  '*.cginc',
+]
+
+[type.shaders.extend-words]
+inout = "inout"
+"#;
+        let mut expected = Config::default();
+        expected.type_.patterns.insert(
+            "shaders".into(),
+            GlobEngineConfig {
+                extend_glob: vec!["*.shader".into(), "*.cginc".into()],
+                engine: EngineConfig {
+                    tokenizer: Some(TokenizerConfig::default()),
+                    dict: Some(DictConfig {
+                        extend_words: maplit::hashmap! {
+                            "inout".into() => "inout".into(),
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let actual = Config::from_toml(input).unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub files: Walk,
@@ -53,7 +54,8 @@ impl Config {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Walk {
     pub extend_exclude: Vec<String>,
@@ -142,7 +144,8 @@ impl Walk {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(transparent)]
 pub struct TypeEngineConfig {
     pub patterns: std::collections::HashMap<kstring::KString, GlobEngineConfig>,
@@ -232,7 +235,8 @@ impl TypeEngineConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct GlobEngineConfig {
     pub extend_glob: Vec<kstring::KString>,
@@ -248,7 +252,8 @@ impl GlobEngineConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct EngineConfig {
     /// Check binary files.
@@ -321,7 +326,8 @@ impl EngineConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TokenizerConfig {
     /// Allow unicode characters in identifiers (and not just ASCII)
@@ -368,7 +374,8 @@ impl TokenizerConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct DictConfig {
     pub locale: Option<Locale>,


### PR DESCRIPTION
We could generate the config with `--dump-config` but could not read it because of problems with serde.