### PR TITLE
Github annotation reporter

### DIFF
--- a/src/bin/typos-cli/args.rs
+++ b/src/bin/typos-cli/args.rs
@@ -6,6 +6,7 @@ use typos_cli::config;
 pub enum Format {
     Silent,
     Brief,
+    Github,
     Long,
     Json,
 }
@@ -18,6 +19,10 @@ impl Format {
     ) -> Box<dyn typos_cli::report::Report> {
         match self {
             Format::Silent => Box::new(crate::report::PrintSilent),
+            Format::Github => Box::new(crate::report::PrintGithub {
+                stdout_palette,
+                stderr_palette,
+            }),
             Format::Brief => Box::new(crate::report::PrintBrief {
                 stdout_palette,
                 stderr_palette,

--- a/src/bin/typos-cli/report.rs
+++ b/src/bin/typos-cli/report.rs
@@ -92,7 +92,7 @@ impl Report for PrintGithub {
                 let column = unicode_segmentation::UnicodeSegmentation::graphemes(start.as_ref(), true).count();
 
                 let col_context = if column > 0 {
-                    format!(",col={},endColumn={},", column, column + msg.typo.len())
+                    format!(",col={},endColumn={}", column, column + msg.typo.len())
                 } else {
                     format!("")
                 };

--- a/src/bin/typos-cli/report.rs
+++ b/src/bin/typos-cli/report.rs
@@ -115,7 +115,7 @@ impl Report for PrintGithub {
                             "::error {}{}::{}",
                             github_context_display(&msg.context),
                             col_context,
-                            format!("`{}` -> {}", msg.typo, itertools::join(corrections.iter().map(|s| format!("`{}`", s)), ", "))
+                            format!("`{}` should be {}", msg.typo, itertools::join(corrections.iter().map(|s| format!("`{}`", s)), ", "))
                         )?;
                     },
                 };


### PR DESCRIPTION
Re #429

```
target/debug/typos --format=github
::error file=./README.md,line=67,col=11,endColumn=18,::`Supress` should be `Suppress`
::error file=./README.md,line=67,col=37,endColumn=44,::`Supress` should be `Suppress`
::error file=./README.md,line=70,col=29,endColumn=32,::`Teh` should be `The`
::error file=./README.md,line=71::`teh` should be `the`
::error file=./README.md,line=71,col=7,endColumn=10,::`teh` should be `the`
::error file=./src/policy.rs,line=362,col=36,endColumn=39,::`THI` should be `THE`, `THIS`
::error file=./src/dict.rs,line=280,col=13,endColumn=23,::`finallizes` should be `finalizes`
::error file=./src/dict.rs,line=334,col=13,endColumn=23,::`finallizes` should be `finalizes`
::error file=./src/config.rs,line=606::`inout` should be `input`
::error file=./src/config.rs,line=606,col=9,endColumn=14,::`inout` should be `input`
::error file=./src/config.rs,line=617,col=29,endColumn=34,::`inout` should be `input`
::error file=./src/config.rs,line=617,col=47,endColumn=52,::`inout` should be `input`
::error file=./CHANGELOG.md,line=54,col=11,endColumn=22,::`requierment` should be `requirement`
::error file=./CHANGELOG.md,line=55,col=11,endColumn=22,::`descrepancy` should be `discrepancy`
::error file=./CHANGELOG.md,line=89,col=11,endColumn=20,::`surrouned` should be `surround`, `surrounded`
::error file=./CHANGELOG.md,line=101,col=7,endColumn=19,::`instantialed` should be `instantiated`
::error file=./CHANGELOG.md,line=228,col=11,endColumn=15,::`ther` should be `there`, `their`, `the`, `other`
::error file=./CHANGELOG.md,line=230,col=3,endColumn=11,::`refernce` should be `reference`
::error file=./tests/cmd/double-escaped.stdin,line=2::`Destory` should be `Destroy`
::error file=./tests/cmd/stdin-failure.stdin,line=1::`Apropriate` should be `Appropriate`
::error file=./tests/cmd/stdin-correct.stdin,line=1::`Apropriate` should be `Appropriate`
::error file=./teh.md::`teh` should be `the`
::error file=./src/file.rs,line=772,col=100,endColumn=105,::`adres` should be `address`
::error file=./src/file.rs,line=774,col=67,endColumn=72,::`adres` should be `address`
```

I don't know how to test this format really. Maybe a github action that just prints it out?