### PR TITLE
New dockerfile for #427.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/target
+Dockerfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
   {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly=1},
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/crate-ci/typos/compare/{{tag_name}}...HEAD", exactly=1},
-  {file="Dockerfile", search="ARG VERSION=.*", replace="ARG VERSION={{version}}", min=1},
   {file="docker/Dockerfile", search="ARG VERSION=.*", replace="ARG VERSION={{version}}", min=1},
   {file="docs/pre-commit.md", search="rev: .*", replace="rev: {{tag_name}}", exactly=1},
   {file="setup.py", search="TYPOS_VERSION = .*", replace="TYPOS_VERSION = '{{version}}'", exactly=1},

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
-ARG VERSION=1.4.0
-ENV VERSION=${VERSION}
-RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/crate-ci/typos/releases/download/v${VERSION}/typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz && \
-    tar -xzvf typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz && \
-    mv typos /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/typos"]
+FROM rust:1.58.1 as builder
+WORKDIR /usr/src/typos
+COPY . .
+RUN cargo install --path .
+
+FROM debian:buster-slim
+COPY --from=builder /usr/local/cargo/bin/typos /usr/local/bin/typos
+CMD ["typos"]


### PR DESCRIPTION
Builds all the binaries on demand, then creates a new image with just the binary.
Easy to do tagged releases or multi arch builds, etc.