### PR TITLE
Correct "opauqe" to "opaque"

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -33652,6 +33652,7 @@ opacy,opacity
 opague,opaque
 opartor,operator
 opatque,opaque
+opauqe,opaque
 opbject,object
 opbjective,objective
 opbjects,objects


### PR DESCRIPTION
I can't find any references to "opauqe" as an actual word, so I believe
this to be safe.

Thanks for this library!