### PR TITLE
feat: Improve Docker image entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN cargo install --path .
 
 FROM debian:buster-slim
 COPY --from=builder /usr/local/cargo/bin/typos /usr/local/bin/typos
-CMD ["typos"]
+ENTRYPOINT ["typos"]
+CMD ["--help"]


### PR DESCRIPTION
Make `typos` the `ENTRYPOINT` rather than cmd, and output `--help` by default.

Provides for better UX when running the image without arguments, and facilitates just passing args to `typos` instead of having to repeat the command name.

BREAKING CHANGE: `typos` must no longer given as the first argument when running the Docker image, as it is the default `ENTRYPOINT` now.