### PR TITLE
feat: Add Docker pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,15 @@
   types: [text]
   stages: [commit, merge-commit, push, manual]
 
+- id: typos-docker
+  name: typos
+  description: Source code spell checker, Docker image
+  language: docker
+  entry: typos
+  args: [--write-changes]
+  types: [text]
+  stages: [commit, merge-commit, push, manual]
+
 - id: typos-src
   name: typos
   description: Source code spell checker, source install

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -13,7 +13,8 @@ repos:
 
 The `typos` id installs a prebuilt executable from GitHub releases. If
 one does not exist for the target platform, or if one built from
-sources is preferred, use `typos-src` as the hook id instead.
+sources is preferred, use `typos-docker` (requires Docker), or `typos-src`
+(requires Rust) as the hook id instead.
 
 Be sure to change `rev` to use the desired `typos` git tag or
 revision.


### PR DESCRIPTION
Mostly as an alternative to the src install, but trading host dependency on Rust with one on Docker.