### PR TITLE
git ignore VS Code config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 target


### PR DESCRIPTION
VS Code is widely used and creates a `.vscode/` folder in the repo for project-specific settings. I think we should ignore that.