### PR TITLE
Document words vs identifiers

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -32,3 +32,18 @@ Dictionary: A confidence rating is given for how close a word is to one in a dic
 - Sensitive to false positives due to hex numbers and c-escapes
 - Used in word processors and other traditional spell checking applications
 - Good when there is a UI to let the user know and override any decisions
+
+## Words vs Identifiers
+
+`typos` reuses Unicode's 'word' and 'identifier' definitions, see in particular [unicode's `XID_Continue`](https://www.unicode.org/reports/tr31/#Table_Lexical_Classes_for_Identifiers).
+The Unicode standard is hard to read, thus here's an incomplete TL;DR that should cover the most common cases for `typos`.
+
+From any text such as `my_string = "Hello TyposWorld"`, identifiers (sequences of words) and words are relevant sequences of characters for our purposes.
+Characters such as spaces separate identifiers from each other, in the example `my_string`, `Hello`, and `TyposWorld`.
+In addition to identifier separators, characters such as underscore are uppercase characters separate words from each other, in the example `my`, `string`, `Hello`, `Typos`, and `World`.
+
+The specific rules are:
+
+- A word is continued when the next character matches `[a-z0-9]`
+- An identifier is continued when the next character matches `[A-Z_]`
+- Other characters separate identifiers and hence words.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ Configuration is read from the following (in precedence order)
 | default.check-file     | \-                | bool   | Verifying spelling in files. |
 | default.unicode        | --unicode         | bool   | Allow unicode characters in identifiers (and not just ASCII) |
 | default.locale         | --locale          | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
-| default.extend-identifiers | \-            | table of strings | Corrections for identifiers (as defined by [unicode's `XID_Continue`](https://www.unicode.org/reports/tr31/)). When the correction is blank, the identifier is never valid. When the correction is the key, the identifier is always valid. |
-| default.extend-words       | \-            | table of strings | Corrections for words (split from identifiers). When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
+| default.extend-identifiers | \-            | table of strings | Corrections for identifiers (groups of words, defined in [design.md](./design.md#words-vs-identifiers)). When the correction is blank, the identifier is never valid. When the correction is the key, the identifier is always valid. |
+| default.extend-words       | \-            | table of strings | Corrections for words (split from identifiers, defined in [design.md](./design.md#words-vs-identifiers)). When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |
 | type.\<name>.\<field>      | \<varied>     | \<varied>  | See `default.` for child keys.  Run with `--type-list` to see available `<name>`s |
 | type.\<name>.extend_globs  | \-            | list of strings  | File globs for matching `<name>` |


### PR DESCRIPTION
Relates to #646: document in simple-to-understand language what makes a word vs what makes an identifier.