### PR TITLE
Allow writing changes in the github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
     required: false
     default: false
 
+  write_changes:
+    description: "Write changes to the repository"
+    required: false
+    default: false
+
   config:
     description: "Use a custom config file."
     required: false

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -43,6 +43,11 @@ if [ "${INPUT_ISOLATED:-false}" == "true" ]; then
     ARGS+=" --isolated"
 fi
 
+# Write changes to the repository
+if [ "${INPUT_WRITE_CHANGES:-false}" == "true" ]; then
+    ARGS+=" --write-changes"
+fi
+
 # Use a custom configuration file
 if [[ -n "${INPUT_CONFIG:-}" ]]; then
     ARGS+=" --config ${INPUT_CONFIG}"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -32,12 +32,22 @@ jobs:
       with: 
         files: ./file.txt
         isolated: true
+
+    - name: Writes changes in the local checkout
+      uses: crate-ci/typos@master
+      with: 
+        write_changes: true
 ```
 
 **Important** for any of the examples above, make sure that you choose
 a release or commit as a version, and not a branch (which is a moving target).
+
 Also make sure when referencing relative file paths to use `./` (e.g., `./file.txt` instead of
 `file.txt`.
+
+`write_changes` doesn't commit or push anything to the branch. It only writes the changes locally
+to disk, and this can be combined with other actions, for instance that will [submit code
+suggestions based on that local diff](https://github.com/getsentry/action-git-diff-suggestions).
 
 ## Variables
 
@@ -46,3 +56,4 @@ Also make sure when referencing relative file paths to use `./` (e.g., `./file.t
 | files| Files or patterns to check | false | If not defined, entire repository is checked |
 | isolated | Ignore implicit configuration files | false | false|
 | config | Use a custom config file (must exist) | false | not set |
+| write_changes | Writes changes on the Action's local checkout | false | false |


### PR DESCRIPTION
Hi! I think it'd make sense to allow writing changes in the github action itself, so that this can be combined with other actions like https://github.com/getsentry/action-git-diff-suggestions. That way, I can run `typos` in my repository, and instead of a hard failure, it will suggest code changes to fix the typos.

See https://github.com/bnjbvr/octotest/pull/5 for an example.

(The entrypoint file will run the command twice, so I suspect that it will only have an effect the first time. I can tweak the script so it doesn't, but as far as I could tell, this didn't add extra warnings or other issues, so that seemed ok to me. Let me know if you'd like me to fix that!)