### PR TITLE
Added `grouepd` to the typos dictionary

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -23191,6 +23191,7 @@ gropus,groups,gropes
 groubdbreaking,groundbreaking
 groubpy,groupby
 groudnbreaking,groundbreaking
+grouepd,grouped
 groupd,grouped
 groupes,groups,grouped
 groupped,grouped


### PR DESCRIPTION
Simple addition of a new typo to the dictionary. `grouepd -> grouped`.