### PR TITLE
feat(dict): Add: erronerous -> erroneous

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -18786,6 +18786,7 @@ erraneously,erroneously
 erro,error
 erroenous,erroneous
 erroneos,erroneous
+erronerous,erroneous
 erroneus,erroneous
 erroneusly,erroneously
 erronous,erroneous


### PR DESCRIPTION
This adds a typo variant that I found in the code base of the [uefi](https://github.com/rust-osdev/uefi-rs) crate.