### PR TITLE
fix: ignore go.mod by default

### DIFF
--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -93,7 +93,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("fut", &["*.fut"]),
     ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
-    ("go", &["*.go", "go.mod"]),
+    ("go", &["*.go"]),
     ("gradle", &["*.gradle"]),
     ("groovy", &["*.groovy", "*.gradle"]),
     ("gzip", &["*.gz", "*.tgz"]),


### PR DESCRIPTION
Fix #683