### PR TITLE
feat(config): Custom ignores

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/args.rs
+++ b/crates/typos-cli/src/bin/typos-cli/args.rs
@@ -156,6 +156,7 @@ impl FileArgs {
                 locale: self.locale,
                 ..Default::default()
             }),
+            extend_ignore_re: Default::default(),
         }
     }
 

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
@@ -1,5 +1,8 @@
 [files]
 extend-exclude = ["_typos.toml"]
 
+[default]
+extend-ignore-re = ["`.*`"]
+
 [default.extend-identifiers]
 hello = "goodbye"

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = ["_typos.toml"]
+
+[default.extend-identifiers]
+hello = "goodbye"

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.in/file.ignore
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.in/file.ignore
@@ -1,0 +1,1 @@
+hello `hello`

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.toml
@@ -1,0 +1,18 @@
+bin.name = "typos"
+stdin = ""
+stdout = """
+error: `hello` should be `goodbye`
+  --> ./file.ignore:1:1
+  |
+1 | hello `hello`
+  | ^^^^^
+  |
+error: `hello` should be `goodbye`
+  --> ./file.ignore:1:8
+  |
+1 | hello `hello`
+  |        ^^^^^
+  |
+"""
+stderr = ""
+status.code = 2

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.toml
@@ -7,12 +7,6 @@ error: `hello` should be `goodbye`
 1 | hello `hello`
   | ^^^^^
   |
-error: `hello` should be `goodbye`
-  --> ./file.ignore:1:8
-  |
-1 | hello `hello`
-  |        ^^^^^
-  |
 """
 stderr = ""
 status.code = 2

--- a/crates/typos/src/check.rs
+++ b/crates/typos/src/check.rs
@@ -86,6 +86,12 @@ impl<'m> Typo<'m> {
             corrections: self.corrections.borrow(),
         }
     }
+
+    pub fn span(&self) -> std::ops::Range<usize> {
+        let start = self.byte_offset;
+        let end = start + self.typo.len();
+        start..end
+    }
 }
 
 impl<'m> Default for Typo<'m> {

--- a/crates/typos/src/tokens.rs
+++ b/crates/typos/src/tokens.rs
@@ -634,6 +634,13 @@ impl<'t> Identifier<'t> {
         self.offset
     }
 
+    #[inline]
+    pub fn span(&self) -> std::ops::Range<usize> {
+        let start = self.offset;
+        let end = start + self.token.len();
+        start..end
+    }
+
     /// Split into individual Words.
     #[inline]
     pub fn split(&self) -> impl Iterator<Item = Word<'t>> {
@@ -701,6 +708,13 @@ impl<'t> Word<'t> {
     #[inline]
     pub fn offset(&self) -> usize {
         self.offset
+    }
+
+    #[inline]
+    pub fn span(&self) -> std::ops::Range<usize> {
+        let start = self.offset;
+        let end = start + self.token.len();
+        start..end
     }
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,6 +27,7 @@ Configuration is read from the following (in precedence order)
 | default.check-file     | \-                | bool   | Verifying spelling in files. |
 | default.unicode        | --unicode         | bool   | Allow unicode characters in identifiers (and not just ASCII) |
 | default.locale         | --locale          | en, en-us, en-gb, en-ca, en-au   | English dialect to correct to. |
+| default.extend-ignore-re   | \-            | list of [regexes](https://docs.rs/regex/latest/regex/index.html#syntax) | Custom uncorrectable sections (e.g. markdown code fences, PGP signatures, etc) |
 | default.extend-identifiers | \-            | table of strings | Corrections for [identifiers](./design.md#identifiers-and-words). When the correction is blank, the identifier is never valid. When the correction is the key, the identifier is always valid. |
 | default.extend-ignore-identifiers-re | \-            | list of [regexes](https://docs.rs/regex/latest/regex/index.html#syntax) | Pattern-match always-valid identifiers |
 | default.extend-words       | \-            | table of strings | Corrections for [words](./design.md#identifiers-and-words). When the correction is blank, the word is never valid. When the correction is the key, the word is always valid. |


### PR DESCRIPTION
Typos primarily works off of identifiers and words.  We have built-in
support to detect constructs that span identifiers that should not be
spell checked, like UUIDs, emails, domains, etc.  This opens it up for
for user-defined identifier-spanning constructs using regexes via
`extend-ignore-re`.

This works differently than any of the previous ways of ignoring thing
because the regexes require extra parse passes.  Under the assumption
that (1) actual typos are rare and (2) number of files relying on
`extend-ignore-re` are rare, we only do these extra parse passes when a
typo is found, causing almost no performance hit in the expected case.

While this could be used for more generic types of ignores, it isn't the
most maintainable because it is separate from the source files in
question.  Ideally, we'd implement document settings / directives for
these cases (#316).