### PR TITLE
Typos?

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -53345,11 +53345,9 @@ zombe,zombie
 zomebie,zombie
 zuser,user
 évaluate,evaluate
-сontain,contain
 сontained,contained
 сontainer,container
 сontainers,containers
 сontaining,containing
 сontainor,container
 сontainors,containers
-сontains,contains


### PR DESCRIPTION
contains -> contains
сontain -> contain

Removed those two lines