### PR TITLE
fix(action) Make wget progress indicator much smaller

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -32,7 +32,7 @@ fi
 if [[ -z $(which ${CMD_NAME} 2>/dev/null) ]]; then
     VERSION=1.14.8
     log "Downloading 'typos' v${VERSION}"
-    wget https://github.com/crate-ci/typos/releases/download/v${VERSION}/typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz
+    wget --progress=dot:mega "https://github.com/crate-ci/typos/releases/download/v${VERSION}/typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz"
     sudo tar -xzvf typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz -C /usr/local/bin ./typos
     rm typos-v${VERSION}-x86_64-unknown-linux-musl.tar.gz
 fi


### PR DESCRIPTION
Because the action runs without a tty, `wget` defaults to `--progress dot`.  This prints a dot per 1K of data.  Due to the size of `typos`, switching to `--progress dot:mega` is better as it only prints one dot per 64K.

```
     0K ........ ........ ........ ........ ........ ........ 51% 11.7M 0s
  3072K ........ ........ ........ ........ ........ .....   100% 12.0M=0.5s
```
