### PR TITLE
fix(dict): Don't correct "accreting"

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -5,3 +5,4 @@ referer,http header field
 deques,noun
 dequeues,verb
 ons,so `add-ons` works
+accreting,verb of accrete

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -687,7 +687,6 @@ accredidation,accreditation
 accreditied,accredited
 accreditted,accredited
 accress,access
-accreting,accrediting
 accroding,according
 accrodingly,accordingly
 accronym,acronym


### PR DESCRIPTION
"accreting" is the present participle of "accrete", see https://en.wiktionary.org/wiki/accreting. Don't correct it to "accrediting".