### PR TITLE
fix(config): Force-skip config files

### DIFF
--- a/crates/typos-cli/src/config.rs
+++ b/crates/typos-cli/src/config.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use kstring::KString;
 
+pub const SUPPORTED_FILE_NAMES: &[&str] = &["typos.toml", "_typos.toml", ".typos.toml"];
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
@@ -17,9 +19,7 @@ pub struct Config {
 
 impl Config {
     pub fn from_dir(cwd: &std::path::Path) -> Result<Option<Self>, anyhow::Error> {
-        let config = if let Some(path) =
-            find_project_file(cwd, &["typos.toml", "_typos.toml", ".typos.toml"])
-        {
+        let config = if let Some(path) = find_project_file(cwd, SUPPORTED_FILE_NAMES) {
             log::debug!("Loading {}", path.display());
             Some(Self::from_file(&path)?)
         } else {

--- a/crates/typos-cli/src/file.rs
+++ b/crates/typos-cli/src/file.rs
@@ -684,6 +684,12 @@ fn walk_entry(
             return Ok(());
         }
     };
+    if crate::config::SUPPORTED_FILE_NAMES
+        .iter()
+        .any(|n| *n == entry.file_name())
+    {
+        return Ok(());
+    }
     if entry.file_type().map(|t| t.is_file()).unwrap_or(true) {
         let explicit = entry.depth() == 0;
         let (path, lookup_path) = if entry.is_stdin() {

--- a/crates/typos-cli/tests/cmd/extend-builtin-dict.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/extend-builtin-dict.in/_typos.toml
@@ -3,8 +3,3 @@ check-filename = false
 
 [default.extend-words]
 foo = "bar"
-
-[files]
-extend-exclude = [
-  "_typos.toml"
-]

--- a/crates/typos-cli/tests/cmd/extend-ignore-identifiers-re.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-identifiers-re.in/_typos.toml
@@ -1,6 +1,3 @@
-[files]
-extend-exclude = ["_typos.toml"]
-
 [default.extend-identifiers]
 hello = "goodbye"
 

--- a/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-re.in/_typos.toml
@@ -1,6 +1,3 @@
-[files]
-extend-exclude = ["_typos.toml"]
-
 [default]
 extend-ignore-re = ["`.*`"]
 

--- a/crates/typos-cli/tests/cmd/override-default-type.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/override-default-type.in/_typos.toml
@@ -4,8 +4,3 @@ check-file = false
 
 [default.extend-words]
 foo = "bar"
-
-[files]
-extend-exclude = [
-  "_typos.toml"
-]


### PR DESCRIPTION
This doesn't use `extend-exclude` which means that `typos typos.toml` will stil be skipped

This doesn't just skip the currently loaded config but any file name that looks like a config, which might be a big aggressive but allows us to do layered config in the future....  We've been saying that for a while.

Fixes #711