### PR TITLE
Mention hidden files in github-action.md

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -53,7 +53,7 @@ suggestions based on that local diff](https://github.com/getsentry/action-git-di
 
 | Name | Description | Required | Default |
 |------|-------------|----------|---------|
-| files| Files or patterns to check | false | If not defined, entire repository is checked |
+| files| Files or patterns to check | false | If not defined, entire repository is checked except hidden files |
 | isolated | Ignore implicit configuration files | false | false|
 | config | Use a custom config file (must exist) | false | not set |
 | write_changes | Writes changes on the Action's local checkout | false | false |


### PR DESCRIPTION
Warn users that the action will not check hidden files.
For example `.github/*`