### PR TITLE
Add support for `pyproject.toml` files

### DIFF
--- a/crates/typos-cli/src/config.rs
+++ b/crates/typos-cli/src/config.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use kstring::KString;
 
-pub const SUPPORTED_FILE_NAMES: &[&str] = &["typos.toml", "_typos.toml", ".typos.toml"];
+pub const SUPPORTED_FILE_NAMES: &[&str] =
+    &["typos.toml", "_typos.toml", ".typos.toml", "pyproject.toml"];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -15,6 +16,20 @@ pub struct Config {
     pub type_: TypeEngineConfig,
     #[serde(skip)]
     pub overrides: EngineConfig,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct PyprojectTomlConfig {
+    pub tool: PyprojectTomlTool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct PyprojectTomlTool {
+    pub typos: Config,
 }
 
 impl Config {
@@ -30,6 +45,11 @@ impl Config {
 
     pub fn from_file(path: &std::path::Path) -> Result<Self, anyhow::Error> {
         let s = std::fs::read_to_string(path)?;
+
+        if path.file_name().unwrap() == "pyproject.toml" {
+            return Ok(toml::from_str::<PyprojectTomlConfig>(&s)?.tool.typos);
+        }
+
         Self::from_toml(&s)
     }
 


### PR DESCRIPTION
This PR adds support for parsing `pyproject.toml` config files. The convention for these files is to put any tooling related configuration into the `tool.NAME` section, so in this case, `tool.typos`. I have verified that the changes are pulled correctly even if the `tool.typos` section is not present.

Closes #361.

PS: I am new to Rust, so let me know if there are any improvements that can be made! I'm new to Serde as well, so I'm unfamiliar with what options do/don't need to be there (I just copied the traits on the `Config` struct).