### PR TITLE
Minify size of release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+strip = true
+lto = true
+codegen-units = 1


### PR DESCRIPTION
See https://github.com/johnthagen/min-sized-rust

Here are some stats on the different flags I used and how much each step reduced the binary size:

|           Method            |        Size        | Diff (%) |
|-----------------------------|--------------------|---------:|
| Master                      | 27633280 (27.6MB)  |      N/A |
| `strip`                     | 19544600 (19.5MB)  |   -29.3% |
| `strip` + `lto`             | 19028504 (19.0MB)  |   -31.1% |
| `strip` + `lto` + `codegen` | 18971160 (19.97MB) |   -31.3% |

Closes #738.