### PR TITLE
fix(dict): Allow `spawnve`

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -12,6 +12,7 @@ pervious,adjective
 perviously,adverb
 referer,http header field
 simulative,adjective
+spawnve,Microsoft-specific function (see https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/spawnve)
 thead,html tag
 unuseful,adjective
 zar,currency code for the South African rand

--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -1,17 +1,17 @@
-nilable,used in ruby community
-thead,html tag
-hardlinked,filesystem term
-referer,http header field
+accreting,verb of accrete
+contiguities,plural of contiguity
 deques,noun
 dequeues,verb
-ons,so `add-ons` works
-accreting,verb of accrete
-zar,currency code for the South African rand
-simulative,adjective
-pervious,adjective
-perviously,adverb
+hardlinked,filesystem term
 intension,noun
 intensional,adjective
 intensionally,adverb
+nilable,used in ruby community
+ons,so `add-ons` works
+pervious,adjective
+perviously,adverb
+referer,http header field
+simulative,adjective
+thead,html tag
 unuseful,adjective
-contiguities,plural of contiguity
+zar,currency code for the South African rand

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -53505,7 +53505,6 @@ spawing,spawning
 spawining,spawning
 spawnig,spawning
 spawnign,spawning
-spawnve,spawn
 spaws,spawns
 spcae,space
 spcaed,spaced

--- a/crates/typos-dict/tests/verify.rs
+++ b/crates/typos-dict/tests/verify.rs
@@ -1,4 +1,5 @@
 use indexmap::IndexSet;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -252,4 +253,19 @@ fn allowed_words() -> std::collections::HashMap<String, String> {
             (typo, reason)
         })
         .collect()
+}
+
+#[test]
+fn allowed_csv_entries_are_sorted_and_unique() {
+    // The order in the csv file does not affect runtime behavior, but we
+    // still want them to be sorted to make the file more human-readable.
+    snapbox::assert_eq_path(
+        "assets/allowed.csv",
+        allowed_words()
+            .iter()
+            .sorted()
+            .unique()
+            .map(|(word, reason)| format!("{word},{reason}\n"))
+            .join(""),
+    );
 }


### PR DESCRIPTION
The first commit sorts `allowed.csv` since it's starting to get uncomfortable for humans.