### PR TITLE
chore: move deprecated package.metadata.maturin

### DIFF
--- a/crates/typos-cli/Cargo.toml
+++ b/crates/typos-cli/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 include.workspace = true
 
-[package.metadata.maturin]
-name = "typos"
-
 [package.metadata.docs.rs]
 no-default-features = true
 

--- a/crates/typos-cli/pyproject.toml
+++ b/crates/typos-cli/pyproject.toml
@@ -15,5 +15,5 @@ classifiers = [
 
 
 [tool.maturin]
-name = "typos"
+module-name = "typos"
 bindings = "bin"

--- a/crates/typos-cli/pyproject.toml
+++ b/crates/typos-cli/pyproject.toml
@@ -15,4 +15,5 @@ classifiers = [
 
 
 [tool.maturin]
+name = "typos"
 bindings = "bin"


### PR DESCRIPTION
PyO3/maturin-action says

> ⚠️ Warning: specify [package.metadata.maturin] name in Cargo.toml is deprecated, use module-name in [tool.maturin] section in pyproject.toml instead
