### PR TITLE
Adds 'verboce' as a typo for 'verbose'.

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -61549,6 +61549,7 @@ verbaly,verbally
 verbatium,verbatim
 verbatum,verbatim
 verboase,verbose
+verboce,verbose
 verbode,verbose
 verbous,verbose
 verbouse,verbose


### PR DESCRIPTION
 Hi,

I propose to add this typo ('verboce' for 'verbose') in the patch included.

Regards.