### PR TITLE
bin: shrink binary size from 26MiB to 18MiB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 codegen-units = 1
+lto = true
+strip = true


### PR DESCRIPTION
The `typos` binary is relatively large. Currently, roughly `26MiB`. We can shrink that down to `18MiB`.

- status quo: `27807000` bytes / `26.52` MiB
- lto: `24852744` bytes / `23.70` MiB
- stripped: `19474952` bytes / `18.57` MiB
- stripped + lto: `18995720` bytes / `18.12` MiB