### PR TITLE
feat: add Code Climate output format

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/args.rs
+++ b/crates/typos-cli/src/bin/typos-cli/args.rs
@@ -10,6 +10,7 @@ pub enum Format {
     #[default]
     Long,
     Json,
+    CodeClimate,
 }
 
 impl Format {
@@ -19,6 +20,7 @@ impl Format {
             Format::Brief => Box::new(crate::report::PrintBrief),
             Format::Long => Box::new(crate::report::PrintLong),
             Format::Json => Box::new(crate::report::PrintJson),
+            Format::CodeClimate => Box::new(crate::report::PrintCodeClimate),
         }
     }
 }


### PR DESCRIPTION
:wave: 

I’m adding the [Code Climate](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types) output format, that can then be used by other tools, such as [GitLab](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscodequality), to display reports without having to dig in logs.

The work is not over yet, but I got to a point where I have something to show. I will improve on what I have, and welcome any feedback you may have for me.

One thing I’m not sure how to do yet is how to get a single JSON array as the output.