### PR TITLE
feat(release): Add linux arm64 build to matrix

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -65,6 +65,10 @@ jobs:
           os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-musl
+        - build: linux
+          os: ubuntu-20.04
+          rust: stable
+          target: arm64-unknown-linux-musl
         - build: macos
           os: macos-latest
           rust: stable


### PR DESCRIPTION
we (`jenkins infra team`) would like to use an ARM64 linux version of typos. 
Reading this issue https://github.com/crate-ci/typos/issues/828 and this PR https://github.com/crate-ci/typos/pull/908 it sounds like it was just missing a build block for linux arm64 ... seem a little too easy but I did this at least to make my contribution to the task.