### PR TITLE
fix(dict): Don't correct JST used in time zone abbreviations

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -23,3 +23,4 @@ foldr,short for fold-right
 eof,end-of-file in programming
 eol,end-of-line in programming
 og,OpenGraph which is used for previews of websites on social media
+jst,abbreviation of Japan Standard Time in tz database

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -34234,7 +34234,6 @@ joystik,joystick
 jpin,join
 jpng,png,jpg,jpeg
 jscipt,jscript
-jst,just
 jstu,just
 jsut,just
 jsutification,justifications


### PR DESCRIPTION
Listed in #955, but `JST` is used as time zone context

https://data.iana.org/time-zones/theory.html
https://github.com/eggert/tz/blob/b1e07fb0779a8075c7f9d862c784dfbd31965c1a/theory.html#L463