### PR TITLE
fix(dict): Don't correct IME

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -23,3 +23,4 @@ foldr,short for fold-right
 eof,end-of-file in programming
 eol,end-of-line in programming
 og,OpenGraph which is used for previews of websites on social media
+ime,abbreviation of Input Method Editor

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -29917,7 +29917,6 @@ imcompatible,incompatible
 imcompetence,incompetence
 imcomplete,incomplete
 imcomprehensible,incomprehensible
-ime,time
 imedatly,immediately
 imedialy,immediately
 imediate,immediate


### PR DESCRIPTION
Listed in https://github.com/crate-ci/typos/issues/955, but `IME` is used as abbreviation of `Input Method Editor`

Examples
---

* https://github.com/microsoft/winget-pkgs/blob/bfe98ffdfa92825c9fc6ecb0975699b518749e97/manifests/g/Google/JapaneseIME/2.29.5370.0/Google.JapaneseIME.installer.yaml#L4
* https://github.com/grammarly/contenteditable/blob/b516071edd25a1df88c3441f0d71fe8f0c5f0cf4/README.md?plain=1#L30