### PR TITLE
feat(dict): Add suggestion "done" for the typo "donw"

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -20605,7 +20605,7 @@ donejuns,dungeons
 donesticated,domesticated
 donig,doing
 donn,done,don
-donw,down
+donw,down,done
 donwgrade,downgrade
 donwgraded,downgraded
 donwload,download


### PR DESCRIPTION
Fixes #968

After this change

```console
> echo "/// If true, the screenshotter was told at startup to quit after it's donw." | ./target/debug/typos -
error: `donw` should be `down`, `done`
  --> -:1:71
  |
1 | /// If true, the screenshotter was told at startup to quit after it's donw.
  |                                                                       ^^^^
  |
```

---

[Above listed typo `donn`](https://github.com/crate-ci/typos/pull/972/files#diff-d7206c435daafa1b53ca9227408de1a1b8c199cb61b5a21973add69b14afd5caL20607) is not related to down, but that is not issued in this 9 months. So I didn't update the `donn` in this PR.