### PR TITLE
fix(dict): Don't correct GUID

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -23,3 +23,4 @@ foldr,short for fold-right
 eof,end-of-file in programming
 eol,end-of-line in programming
 og,OpenGraph which is used for previews of websites on social media
+guid,globally-unique-identifier in programming

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -28272,7 +28272,6 @@ guerrilas,guerrillas
 guerrillera,guerrilla
 guesss,guess,guesses
 gueswork,guesswork
-guid,guide
 guideance,guidance
 guideded,guided
 guidence,guidance


### PR DESCRIPTION
Listed in #955, but GUID is used for abbreviation of Globally Unique Identifier, especially in Windows

Examples
---

* https://github.com/microsoft/terminal/blob/9f3dbab7bf442a1d7702bef0058fa2f0ff5736cd/src/types/utils.cpp#L48-L50