### PR TITLE
fix: Don't correct common Python identifiers

### DIFF
--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -41,7 +41,9 @@ pub const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
         "py",
         StaticDictConfig {
             ignore_idents: &[
-                "NDArray", // numpy.typing.NDArray
+                "NDArray",  // numpy.typing.NDArray
+                "EOFError", // std
+                "arange",   // torch.arange, numpy.arange
             ],
             ignore_words: &[],
         },


### PR DESCRIPTION
Fixes #966
Fixes #969