### PR TITLE
Add more python file extensions

### DIFF
--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -184,7 +184,9 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("puppet", &["*.erb", "*.pp", "*.rb"]),
     ("purs", &["*.purs"]),
     ("py", &[
+        "*.ipynb",
         "*.py",
+        "*.pyi",
         // From a spell-check perspective, this is more like Python than toml
         "pyproject.toml",
     ]),

--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -184,7 +184,6 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("puppet", &["*.erb", "*.pp", "*.rb"]),
     ("purs", &["*.purs"]),
     ("py", &[
-        "*.ipynb",
         "*.py",
         "*.pyi",
         // From a spell-check perspective, this is more like Python than toml


### PR DESCRIPTION
Add more python file extensions. Namely `.ipynb` for jupyter notebook files, and `.pyi` for stub files.