### PR TITLE
fix(dict): Don't correct dBA

### DIFF
--- a/crates/typos-cli/src/dict.rs
+++ b/crates/typos-cli/src/dict.rs
@@ -54,6 +54,7 @@ impl BuiltIn {
     fn correct_ident_with_dict<'s>(&self, ident: &str) -> Option<Status<'s>> {
         match ident {
             "O_WRONLY" => Some(Status::Valid),
+            "dBA" => Some(Status::Valid),
             _ => None,
         }
     }

--- a/crates/typos-cli/tests/cmd/false-positives.in/sample.txt
+++ b/crates/typos-cli/tests/cmd/false-positives.in/sample.txt
@@ -1,0 +1,1 @@
+Audio volume: 23.6 dBA

--- a/crates/typos-cli/tests/cmd/false-positives.toml
+++ b/crates/typos-cli/tests/cmd/false-positives.toml
@@ -1,4 +1,12 @@
 bin.name = "typos"
 stdin = ""
-stdout = ""
+stdout = """
+error: `BA` should be `BY`, `BE`
+  --> ./sample.txt:1:21
+  |
+1 | Audio volume: 23.6 dBA
+  |                     ^^
+  |
+"""
 stderr = ""
+status.code = 2

--- a/crates/typos-cli/tests/cmd/false-positives.toml
+++ b/crates/typos-cli/tests/cmd/false-positives.toml
@@ -1,12 +1,4 @@
 bin.name = "typos"
 stdin = ""
-stdout = """
-error: `BA` should be `BY`, `BE`
-  --> ./sample.txt:1:21
-  |
-1 | Audio volume: 23.6 dBA
-  |                     ^^
-  |
-"""
+stdout = ""
 stderr = ""
-status.code = 2


### PR DESCRIPTION
I went with the direct unit which will be considered and identifier by
the casing, rather than also allowing this as a word.

Fixes #997