### PR TITLE
fix(dict): ignore flate for Go files

### DIFF
--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -17,6 +17,15 @@ pub(crate) const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
         },
     ),
     (
+        "go",
+        StaticDictConfig {
+            ignore_idents: &[
+                "flate", // https://pkg.go.dev/compress/flate
+            ],
+            ignore_words: &[],
+        },
+    ),
+    (
         "jl",
         StaticDictConfig {
             ignore_idents: &[],


### PR DESCRIPTION
`flate` is part of the standard library.