### PR TITLE
docs(ref): Add dotall specifier to block ignore

### DIFF
--- a/crates/typos-cli/tests/cmd/ignore-block.in/_typos.toml
+++ b/crates/typos-cli/tests/cmd/ignore-block.in/_typos.toml
@@ -1,5 +1,5 @@
 [default]
-extend-ignore-re = ["#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"]
+extend-ignore-re = ["(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"]
 
 [default.extend-identifiers]
 hello = "goodbye"

--- a/crates/typos-cli/tests/cmd/ignore-block.in/file.ignore
+++ b/crates/typos-cli/tests/cmd/ignore-block.in/file.ignore
@@ -1,5 +1,9 @@
 hello
 # spellchecker:off
 hello
-# spellchecker:on
+henlo
+// spellchecker:on
 hello
+// ensure greedy doesn't exclude everything across blocks
+# spellchecker:off
+# spellchecker:on

--- a/crates/typos-cli/tests/cmd/ignore-block.toml
+++ b/crates/typos-cli/tests/cmd/ignore-block.toml
@@ -8,9 +8,9 @@ error: `hello` should be `goodbye`
   | ^^^^^
   |
 error: `hello` should be `goodbye`
-  --> ./file.ignore:5:1
+  --> ./file.ignore:6:1
   |
-5 | hello
+6 | hello
   | ^^^^^
   |
 """

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,8 +39,8 @@ Configuration is read from the following (in precedence order)
 | type.\<name>.extend-glob   | \-            | list of strings  | File globs for matching `<name>` |
 
 Common `extend-ignore-re`:
-- Line ignore with trailing `# spellchecker:disable-line`: `"(?Rm)^.*#\\s*spellchecker:disable-line$"`
-- Line block with `# spellchecker:<on|off>`: `"#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"`
+- Line ignore with trailing `# spellchecker:disable-line`: `"(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"`
+- Line block with `# spellchecker:<on|off>`: `"(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"`
 
 Common `extend-ignore-identifiers-re`:
 - SSL Cipher suites: `"\\bTLS_[A-Z0-9_]+(_anon_[A-Z0-9_]+)?\\b"`


### PR DESCRIPTION
Needed a `(?s)` to match multiple enclosed newlines. And added a non-greedy modifier and matching test to prevent double blocks from causing intermediate lines to be ignored:

```shell
# spellchecker:off
should be ignored
# spellchecker:on
should not be ignored  # without non-greedy, this is also ignored
# spellchecker:off
should be ignored
# spellchecker:on
```

And tweak the examples to support both `#` and `//` comment leaders.