### PR TITLE
Fix trailing spaces

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -18,24 +18,24 @@ jobs:
 
     - name: Check spelling of file.txt
       uses: crate-ci/typos@master
-      with: 
+      with:
         files: ./file.txt
 
     - name: Use custom config file
       uses: crate-ci/typos@master
-      with: 
+      with:
         files: ./file.txt
         config: ./myconfig.toml
 
     - name: Ignore implicit configuration file
       uses: crate-ci/typos@master
-      with: 
+      with:
         files: ./file.txt
         isolated: true
 
     - name: Writes changes in the local checkout
       uses: crate-ci/typos@master
-      with: 
+      with:
         write_changes: true
 ```
 


### PR DESCRIPTION
Very minor, but I noticed a few trailing spaces when copy-pasting the GitHub action.