### PR TITLE
Add GitHub Actions with suggestions using reviewdog integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE)
   - [False Positives](#false-positives)
   - [Integrations](#integrations)
     - [GitHub Action](docs/github-action.md)
+    - [GitHub Action with suggestions using reviewdog](https://github.com/reviewdog/action-typos)
     - [pre-commit](docs/pre-commit.md)
     - [Custom](#custom)
   - [Debugging](#debugging)
@@ -111,6 +112,7 @@ extend-exclude = ["localized/*.po"]
 ### Integrations
 
 - [GitHub Actions](docs/github-action.md)
+- [GitHub Actions with suggestions using reviewdog](https://github.com/reviewdog/action-typos)
 - [pre-commit](docs/pre-commit.md)
 - [🐊Putout Processor](https://github.com/putoutjs/putout-processor-typos)
 - [Visual Studio Code](https://github.com/tekumara/typos-vscode)


### PR DESCRIPTION
I created a yet another GitHub Actions which runs typos with reviewdog.
https://github.com/reviewdog/action-typos

It also support posting comments with GitHub Code Suggestions feature.

![image](https://github.com/reviewdog/action-typos/assets/3797062/cd33d6b6-3df7-46f0-8718-11985aa12e80)

I'm not sure it's appropriate to add different actions in the documentation,
but I just wanted to share it as it's handy if suggestion feature is supported.

Please feel free to close it.

Thanks!

