### PR TITLE
fix the crate install path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_DIST=bullseye
 FROM rust:${DEBIAN_DIST} as builder
 WORKDIR /usr/src/typos
 COPY . .
-RUN cargo install --path .
+RUN cargo install --path ./crates/typos-cli
 
 FROM debian:${DEBIAN_DIST}-slim
 COPY --from=builder /usr/local/cargo/bin/typos /usr/local/bin/typos


### PR DESCRIPTION
The Dockerfile might have been old (from before the project was a workspace) and the path to the installable crate was wrong. 

This also broke the pre-commit docker hook, which was important for me since I couldn't get the default one to work on NixOS.