### PR TITLE
fix(dict): Add suggestions "greater" and "gather" for the typo "grather"

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -28800,7 +28800,7 @@ grassrooters,grassroots
 grat,great
 gratefull,grateful
 gratful,grateful
-grather
+grather,greater,gather
 gratificacion,gratification
 gratificaiton,gratification
 gratituous,gratuitous


### PR DESCRIPTION
Sorry, I might have written a [wrongly formatted request](https://github.com/crate-ci/typos/issues/1069#issuecomment-2271530487) for multiple candidates. 

```plaintext
grather -> greater|gather
```

Typos now detect it as a disallowed word. I don't have confidence that this is valid or invalid because this pattern is not found for other entries.

Current
---

```console
> cargo test --workspace --no-run

> echo 'grather' | ./target/debug/typos --version -
typos-cli 1.24.3

> echo 'grather' | ./target/debug/typos -
error: `grather` is disallowed
  --> -:1:1
  |
1 | grather
  | ^^^^^^^
  |
```

After this change
---

```console
> echo 'grather' | ./target/debug/typos -
error: `grather` should be `greater`, `gather`
  --> -:1:1
  |
1 | grather
  | ^^^^^^^
  |
```