### PR TITLE
feat(action): Add Windows support to actions

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -6,11 +6,15 @@ jobs:
     name: Spell Check with Typos
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v4
+
+    - name: Install wget for Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install wget --no-progress
 
     - name: Prepare file with mistakes.
       run: echo "Finallizes" > file.txt
@@ -31,13 +35,17 @@ jobs:
     name: Spell Check with Type w/History
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Install wget for Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install wget --no-progress
 
     - name: Prepare file with mistakes.
       run: echo "Finallizes" > file.txt

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -27,16 +27,26 @@ if [[ ! -x ${COMMAND} ]]; then
     else
         ARCH="x86_64"
     fi
-    if [[ "$(uname -s)" == "Darwin" ]]; then
+    UNAME=$(uname -s)
+    if [[ "$UNAME" == "Darwin" ]]; then
         TARGET_FILE="${ARCH}-apple-darwin"
+        FILE_EXT="tar.gz"
+    elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]] ; then
+        TARGET_FILE="${ARCH}-pc-windows-msvc"
+        FILE_EXT="zip"
     else
         TARGET_FILE="${ARCH}-unknown-linux-musl"
+        FILE_EXT="tar.gz"
     fi
-    FILE_NAME="typos-v${VERSION}-${TARGET_FILE}.tar.gz"
+    FILE_NAME="typos-v${VERSION}-${TARGET_FILE}.${FILE_EXT}"
     log "Downloading 'typos' v${VERSION}"
     wget --progress=dot:mega "https://github.com/crate-ci/typos/releases/download/v${VERSION}/${FILE_NAME}"
     mkdir -p ${_INSTALL_DIR}
-    tar -xzvf "${FILE_NAME}" -C ${_INSTALL_DIR} ./${CMD_NAME}
+    if [[ "$FILE_EXT" == "zip" ]]; then
+        unzip -o "${FILE_NAME}" -d ${_INSTALL_DIR} ${CMD_NAME}.exe
+    else
+        tar -xzvf "${FILE_NAME}" -C ${_INSTALL_DIR} ./${CMD_NAME}
+    fi
     rm "${FILE_NAME}"
 fi
 log "jq: $(jq --version)"


### PR DESCRIPTION
This PR contains changes to the GitHub Actions workflow to add support for Windows with Cygwin, MSYS2, and MinGW.

Related tests have been added to ensure that the changes work as expected. Currently it is necessary to manually install wget for Github Actions' Windows runner to work with typos.