### PR TITLE
feat(action): Add support for force-exclude option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ inputs:
     required: false
     default: false
 
+  force_exclude:
+    description: "Force exclude of files or patterns"
+    required: false
+    default: false
+
   config:
     description: "Use a custom config file."
     required: false
@@ -42,6 +47,7 @@ runs:
         INPUT_EXTEND_WORDS: ${{ inputs.extend_words }}
         INPUT_ISOLATED: ${{ inputs.isolated }}
         INPUT_WRITE_CHANGES: ${{ inputs.write_changes }}
+        INPUT_FORCE_EXCLUDE: ${{ inputs.force_exclude }}
         INPUT_CONFIG: ${{ inputs.config }}
 
 branding:

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -63,6 +63,11 @@ if [ "${INPUT_WRITE_CHANGES:-false}" == "true" ]; then
     ARGS+=" --write-changes"
 fi
 
+# Force exclude of files or patterns
+if [ "${INPUT_FORCE_EXCLUDE:-false}" == "true" ]; then
+    ARGS+=" --force-exclude"
+fi
+
 # Use a custom configuration file
 if [[ -n "${INPUT_CONFIG:-}" ]]; then
     ARGS+=" --config ${INPUT_CONFIG}"


### PR DESCRIPTION
When using typos with changed-files, the `extend-exclude` setting in the configuration file is ignored, leading to checks on unwanted directories.

This update ensures target directories are consistently ignored and avoids unnecessary validations.