### PR TITLE
Updates stage names in `.pre-commit-hooks.yaml`.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   entry: typos
   args: [--write-changes, --force-exclude]
   types: [text]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: typos-docker
   name: typos
@@ -14,7 +14,7 @@
   entry: typos
   args: [--write-changes, --force-exclude]
   types: [text]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: typos-src
   name: typos
@@ -23,4 +23,4 @@
   entry: typos
   args: [--write-changes, --force-exclude]
   types: [text]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]


### PR DESCRIPTION
The stage names were updated in pre-commit v4 and the old names are deprecated.

- https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0
- https://pre-commit.com/#confining-hooks-to-run-at-certain-stages