### PR TITLE
test(dict): Don't use unverified varcon

### DIFF
--- a/crates/typos-dict/tests/verify.rs
+++ b/crates/typos-dict/tests/verify.rs
@@ -194,6 +194,7 @@ fn varcon_words() -> HashSet<UniCase<&'static str>> {
     // dictionary
     varcon::VARCON
         .iter()
+        .filter(|c| c.verified)
         .flat_map(|c| c.entries.iter())
         .flat_map(|e| e.variants.iter())
         .map(|v| UniCase::new(v.word))


### PR DESCRIPTION
This mirrors 17b4d0267eab0b23ff9c704ca0fcf1f2de7ea036