### PR TITLE
fix(dict): allow `muc`

### DIFF
--- a/crates/typos-dict/assets/allowed.csv
+++ b/crates/typos-dict/assets/allowed.csv
@@ -48,3 +48,4 @@ tesselating,potentially US variant of tessellating
 tesselation,potentially US variant of tessellation
 tesselator,potentially US variant of tessellator
 additionals,additional looks like its sometimes a countable noun
+muc,iata code for Munich Airport and widely used shorthand for the city of Munich

--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -40665,7 +40665,6 @@ msytical,mystical
 mthod,method
 mthods,methods
 mtuually,mutually
-muc,much
 mucisians,musicians
 mucnhies,munchies
 mucuous,mucous


### PR DESCRIPTION
In my opinion, `muc` should not be auto-corrected to `much`. [MUC is the IATA-code of the Munich airport](https://en.wikipedia.org/wiki/Munich_Airport) and a widely used shorthand for Munich.