### PR TITLE
feat: Recognize dtso as devicetree type

### DIFF
--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -76,7 +76,7 @@ pub(crate) const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("cython", &["*.pyx", "*.pxi", "*.pxd"]),
     ("d", &["*.d"]),
     ("dart", &["*.dart"]),
-    ("devicetree", &["*.dts", "*.dtsi"]),
+    ("devicetree", &["*.dts", "*.dtsi", "*.dtso"]),
     ("dhall", &["*.dhall"]),
     ("diff", &["*.patch", "*.diff"]),
     ("dita", &["*.dita", "*.ditamap", "*.ditaval"]),


### PR DESCRIPTION
This adds dtso (device tree source overlay) as a recognized devicetree type.