### PR TITLE
feat(infra): Publish Docker image on release

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,75 @@
+# The way this works is the following:
+#
+# The publish-docker-image job runs when a release is created, hence after post-release job.
+# The steps are:
+#  - Log in to the Container registry (example: ghcr.io/create-ci).
+#  - Extract metadata (tags, labels) for Docker image.
+#  - Build and push Docker image to the container registry.
+#    Image tags are "latest" and the semver tag (without the "v" prefix).
+#  - Generate artifact attestation.
+#
+# Reference:
+# https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+name: publish-docker-image
+on:
+  workflow_run:
+    workflows: [post-release]
+    types:
+      - completed
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # docker/metadata-action extracts the tag from the event that triggered the workflow.
+      # Since the workflow was triggered by another workflow, the tag is the branch name (e.g. master).
+      # Use `git tag --merged $branch` to get the semver tag for the docker image.
+      - name: Extract tag from master
+        run: echo "TAG=$(git tag --merged ${{ github.ref_name }})" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.TAG }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
The post-release job will trigger the publish-docker-image job which builds and pushes the image to the GitHub Container Registry (ghcr.io). The image is tagged with the `semver tag` and `latest`.

Regarding https://github.com/crate-ci/typos/issues/427#issuecomment-1031618262, even a focused image can be helpful for local development and testing. I think it would be beneficial to start publishing the image even if it might change in the future.

Fixes: #427 