### PR TITLE
docs: add linkable header to example configurations

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,6 +39,8 @@ Configuration is read from the following (in precedence order)
 | type.\<name>.\<field>      | \<varied>     | \<varied> | \<varied> | See `default.` for child keys.  Run with `--type-list` to see available `<name>`s. |
 | type.\<name>.extend-glob   | \-            | list of strings | \- | File globs for matching `<name>`. |
 
+### Example configurations
+
 Common `extend-ignore-re`:
 - Line ignore with trailing `# spellchecker:disable-line`: `"(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"`
 - Line block with `# spellchecker:<on|off>`: `"(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"`


### PR DESCRIPTION
Config Fields is quite a section, and if you want to make a reference directly to the very helpful extend-ignore-re examples today you can't.