### PR TITLE
Do not correct seeked word

### DIFF
--- a/crates/typos-dict/assets/words.csv
+++ b/crates/typos-dict/assets/words.csv
@@ -57404,7 +57404,6 @@ seege,siege
 seeged,sieged
 seeges,sieges
 seeging,sieging
-seeked,sought
 seelct,select
 seelction,selection
 seelect,select

--- a/crates/wikipedia-dict/assets/dictionary.txt
+++ b/crates/wikipedia-dict/assets/dictionary.txt
@@ -3477,7 +3477,6 @@ seceeded->succeeded, seceded
 secratary->secretary
 secretery->secretary
 sedereal->sidereal
-seeked->sought
 segementation->segmentation
 seguoys->segues
 seige->siege


### PR DESCRIPTION
The word seeked is used for simplicity in the [web api](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeked_event) and when you work a lot with different video and media related project on the web it becomes really annoying that typos is always referring this in every project (and actually throws an error even when you open lib.dom.ts the typescript bindings to web api). 

I tried to check your misspelled implementation but it looks it using some totally abandoned project https://github.com/client9/misspell so I decided to just exclude it in the most naive way. Please let me know if something lese needs to be done 