### PR TITLE
feat(cli): Add '--highlight-<identifiers|words>' flags

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/args.rs
+++ b/crates/typos-cli/src/bin/typos-cli/args.rs
@@ -77,9 +77,17 @@ pub(crate) struct Args {
     #[arg(long, group = "mode", help_heading = "Mode")]
     pub(crate) file_types: bool,
 
+    /// Debug: Print back out files, stylizing identifiers that would be spellchecked.
+    #[arg(long, group = "mode", help_heading = "Mode")]
+    pub(crate) highlight_identifiers: bool,
+
     /// Debug: Print each identifier that would be spellchecked.
     #[arg(long, group = "mode", help_heading = "Mode")]
     pub(crate) identifiers: bool,
+
+    /// Debug: Print back out files, stylizing words that would be spellchecked.
+    #[arg(long, group = "mode", help_heading = "Mode")]
+    pub(crate) highlight_words: bool,
 
     /// Debug: Print each word that would be spellchecked.
     #[arg(long, group = "mode", help_heading = "Mode")]

--- a/crates/typos-cli/src/bin/typos-cli/main.rs
+++ b/crates/typos-cli/src/bin/typos-cli/main.rs
@@ -288,8 +288,12 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
             &typos_cli::file::FoundFiles
         } else if args.file_types {
             &typos_cli::file::FileTypes
+        } else if args.highlight_identifiers {
+            &typos_cli::file::HighlightIdentifiers
         } else if args.identifiers {
             &typos_cli::file::Identifiers
+        } else if args.highlight_words {
+            &typos_cli::file::HighlightWords
         } else if args.words {
             &typos_cli::file::Words
         } else if args.write_changes {

--- a/crates/typos-cli/tests/cmd/help.toml
+++ b/crates/typos-cli/tests/cmd/help.toml
@@ -38,7 +38,11 @@ Mode:
   -w, --write-changes              Write fixes out
       --files                      Debug: Print each file that would be spellchecked
       --file-types                 Debug: Print each file's type
+      --highlight-identifiers      Debug: Print back out files, stylizing identifiers that would be
+                                   spellchecked
       --identifiers                Debug: Print each identifier that would be spellchecked
+      --highlight-words            Debug: Print back out files, stylizing words that would be
+                                   spellchecked
       --words                      Debug: Print each word that would be spellchecked
       --dump-config <DUMP_CONFIG>  Write the current configuration to file with `-` for stdout
       --type-list                  Show all supported file types


### PR DESCRIPTION
This makes it easier to evaluate word splitting

![image](https://github.com/user-attachments/assets/5a8a184f-f2c1-4ea0-b485-b81d67f3ffa5)


Fixes #1254