### PR TITLE
feat(cli): ignore `.git` directory by default

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/main.rs
+++ b/crates/typos-cli/src/bin/typos-cli/main.rs
@@ -238,8 +238,14 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
         let single_threaded = threads == 1;
 
         let mut walk = ignore::WalkBuilder::new(path);
+        let overrides = ignore::overrides::OverrideBuilder::new(".")
+            .add(".git/")
+            .with_code(proc_exit::sysexits::CONFIG_ERR)?
+            .build()
+            .with_code(proc_exit::sysexits::CONFIG_ERR)?;
         walk.threads(threads)
             .skip_stdout(true)
+            .overrides(overrides)
             .hidden(walk_policy.ignore_hidden())
             .ignore(walk_policy.ignore_dot())
             .git_global(walk_policy.ignore_global())


### PR DESCRIPTION
Fixes https://github.com/crate-ci/typos/issues/788.

Since the `ignore` crate doesn't support this directly, I added an `overrides` option to explicitly ignore the `.git` directory.
ref: https://github.com/BurntSushi/ripgrep/issues/2964

If it's preferable to set a default `extend_exclude` and merge it instead, I'm happy to refactor accordingly.

Apologies for the lack of tests and documentation.
I couldn't include tests because the `.git` directory is ignored by Git itself.
As for documentation, I wasn't sure where this should be documented. Could you advise me on the appropriate place to add it?