### PR TITLE
fix(cli): Don't recognize "typ" as typo in .typ files

### DIFF
--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -315,6 +315,7 @@ pub(crate) const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("ts", &["*.ts", "*.tsx", "*.cts", "*.mts"]),
     ("twig", &["*.twig"]),
     ("txt", &["*.txt"]),
+    ("typ", &["*.typ"]),
     ("typoscript", &["*.typoscript"]),
     ("usd", &["*.usd", "*.usda", "*.usdc"]),
     ("v", &["*.v", "*.vsh"]),

--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -88,6 +88,15 @@ pub(crate) const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
         },
     ),
     (
+        "typ", // Typst
+        StaticDictConfig {
+            ignore_idents: &[
+                "typ", // file extension
+            ],
+            ignore_words: &[],
+        },
+    ),
+    (
         "vimscript",
         StaticDictConfig {
             ignore_idents: &[


### PR DESCRIPTION
Before the file extension of Typst was recognized as a typo.

Fixes #1253.