### PR TITLE
fix: Revert "fix: ignore go.mod by default"

### DIFF
--- a/crates/typos-cli/src/default_types.rs
+++ b/crates/typos-cli/src/default_types.rs
@@ -102,7 +102,7 @@ pub(crate) const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("fut", &["*.fut"]),
     ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
-    ("go", &["*.go", "go.work"]),
+    ("go", &["*.go", "go.mod", "go.work"]),
     ("gprbuild", &["*.gpr"]),
     ("gradle", &[
         "*.gradle", "*.gradle.kts", "gradle.properties", "gradle-wrapper.*",


### PR DESCRIPTION
This reverts commit 4eeb460bb7575dcee03f2419e7331f71bc27b7c5.

Original PR: #684

Original Issue: #683

This didn't cause `go.mod` to be ignored instead it caused it to not be counted as go code.
However, `go.mod` and `go.work` are similar file types and both are more of package specifications than lock files or other machine-only content.

See #1363