### PR TITLE
fix(dict): don't correct typ in Go files

### DIFF
--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -39,6 +39,7 @@ pub(crate) const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
         StaticDictConfig {
             ignore_idents: &[
                 "flate", // https://pkg.go.dev/compress/flate
+                "typ",   // type is a reserved word in Go, so typ is often used instead when handling types
             ],
             ignore_words: &[],
         },


### PR DESCRIPTION
type is a reserved word in Go.

As a consequence, typ is often used instead when handling types.

Here is a GitHub search about it [`language:go /[ \.]typ\W/`](https://github.com/search?q=language%3Ago%20%2F%5B%20%5C.%5Dtyp%5CW%2F&type=code)

Also, this term is often whitelisted on project using `typos`

[`language:toml path:/typos.toml/ /"typ"/`](https://github.com/search?q=language%3Atoml%20path%3A%2Ftypos.toml%2F%20%2F%22typ%22%2F&type=code)

Maybe more language could exclude `typ`, but I limited my PR to Go for now