### PR TITLE
fix(dict): add Go exclusions

### DIFF
--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -38,7 +38,15 @@ pub(crate) const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
         "go",
         StaticDictConfig {
             ignore_idents: &[
-                "flate", // https://pkg.go.dev/compress/flate
+                "flate",                               // https://pkg.go.dev/compress/flate
+                "Rela32",                              // https://pkg.go.dev/debug/elf#Rela32
+                "Rela64",                              // https://pkg.go.dev/debug/elf#Rela64
+                "NewCBCEncrypter", // https://pkg.go.dev/crypto/cipher#NewCBCEncrypter
+                "NewCFBEncrypter", // https://pkg.go.dev/crypto/cipher#NewCFBEncrypter
+                "O_WRONLY", // https://pkg.go.dev/os#O_WRONLY and https://pkg.go.dev/syscall#O_WRONLY
+                "NOTE_FFOR", // https://pkg.go.dev/syscall?GOOS=darwin#NOTE_FFOR
+                "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", // https://pkg.go.dev/crypto/tls#TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+                "TLS_RSA_WITH_3DES_EDE_CBC_SHA", // https://pkg.go.dev/crypto/tls#TLS_RSA_WITH_3DES_EDE_CBC_SHA
             ],
             ignore_words: &[],
         },


### PR DESCRIPTION
Here are some stats about the usage of these method/types

- [cipher.NewCBCEncrypter](https://github.com/search?q=language%3Ago%20%2Fcipher%5C.NewCBCEncrypter%2F%20-is%3Afork&type=code)
- [cipher.NewCFBEncrypter](https://github.com/search?q=language%3Ago%20%2Fcipher%5C.NewCFBEncrypter%2F%20-is%3Afork&type=code)
- [elf.Rela32 and elf.Rela64](https://github.com/search?q=language%3Ago%20%2Felf%5C.Rela(32%7C64)%2F%20-is%3Afork&type=code)
- [os.O_WRONLY or syscall.O_WRONLY](https://github.com/search?q=language%3Ago%20%2F(os|syscall)%5C.O_WRONLY%2F%20-is%3Afork&type=code)
- [syscall.NOTE_FFOR](https://github.com/search?q=language%3Ago%20%2Fsyscall%5C.NOTE_FFOR%2F%20-is%3Afork&type=code)

https://pkg.go.dev/debug/elf#Rela32
https://pkg.go.dev/debug/elf#Rela64
https://pkg.go.dev/crypto/cipher#NewCBCEncrypter
https://pkg.go.dev/os#O_WRONLY
https://pkg.go.dev/syscall#O_WRONLY
https://pkg.go.dev/syscall?GOOS=darwin#NOTE_FFOR