### PR TITLE
feat: support for files which extend ignored words and/or identifiers

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/args.rs
+++ b/crates/typos-cli/src/bin/typos-cli/args.rs
@@ -54,6 +54,20 @@ pub(crate) struct Args {
     #[arg(short = 'c', long = "config", help_heading = "Config")]
     pub(crate) custom_config: Option<std::path::PathBuf>,
 
+    /// Path to a file specifying identifiers which are to be ignored .
+    ///
+    /// The specified file should be UTF-8 encoded, and identifiers should
+    /// be separated by whitespace.
+    #[arg(long, help_heading = "Config")]
+    pub(crate) ignore_identifiers_file: Option<std::path::PathBuf>,
+
+    /// Path to a file specifying words which are to be ignored.
+    ///
+    /// The specified file should be UTF-8 encoded, and identifiers should
+    /// be separated by whitespace.
+    #[arg(long, help_heading = "Config")]
+    pub(crate) ignore_words_file: Option<std::path::PathBuf>,
+
     /// Ignore implicit configuration files.
     #[arg(long, help_heading = "Config")]
     pub(crate) isolated: bool,

--- a/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.in/file.txt
+++ b/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.in/file.txt
@@ -1,0 +1,3 @@
+Testng DIFFERENTIATIATIONS
+ratatui aand  Microtransactional
+aanother

--- a/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.in/ignore.txt
+++ b/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.in/ignore.txt
@@ -1,0 +1,3 @@
+testng
+ratatui
+aand aanother

--- a/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-identifiers-file.toml
@@ -1,0 +1,22 @@
+bin.name = "typos"
+args = "--ignore-identifiers-file ignore.txt file.txt"
+status.code = 2
+stdin = ""
+stdout = """
+error: `Testng` should be `Testing`
+  ╭▸ file.txt:1:1
+  │
+1 │ Testng DIFFERENTIATIATIONS
+  ╰╴━━━━━━
+error: `DIFFERENTIATIATIONS` should be `DIFFERENTIATIONS`
+  ╭▸ file.txt:1:8
+  │
+1 │ Testng DIFFERENTIATIATIONS
+  ╰╴       ━━━━━━━━━━━━━━━━━━━
+error: `Microtransactional` should be `Microtransactions`
+  ╭▸ file.txt:2:15
+  │
+2 │ ratatui aand  Microtransactional
+  ╰╴              ━━━━━━━━━━━━━━━━━━
+"""
+stderr = ""

--- a/crates/typos-cli/tests/cmd/extend-ignore-words-file.in/file.txt
+++ b/crates/typos-cli/tests/cmd/extend-ignore-words-file.in/file.txt
@@ -1,0 +1,3 @@
+testng differentiatiations
+ratatui aand microtransactional
+aanother

--- a/crates/typos-cli/tests/cmd/extend-ignore-words-file.in/ignore.txt
+++ b/crates/typos-cli/tests/cmd/extend-ignore-words-file.in/ignore.txt
@@ -1,0 +1,3 @@
+testng
+ratatui
+aand aanother

--- a/crates/typos-cli/tests/cmd/extend-ignore-words-file.toml
+++ b/crates/typos-cli/tests/cmd/extend-ignore-words-file.toml
@@ -1,0 +1,17 @@
+bin.name = "typos"
+args = "--ignore-words-file ignore.txt file.txt"
+status.code = 2
+stdin = ""
+stdout = """
+error: `differentiatiations` should be `differentiations`
+  ╭▸ file.txt:1:8
+  │
+1 │ testng differentiatiations
+  ╰╴       ━━━━━━━━━━━━━━━━━━━
+error: `microtransactional` should be `microtransactions`
+  ╭▸ file.txt:2:14
+  │
+2 │ ratatui aand microtransactional
+  ╰╴             ━━━━━━━━━━━━━━━━━━
+"""
+stderr = ""

--- a/crates/typos-cli/tests/cmd/help.toml
+++ b/crates/typos-cli/tests/cmd/help.toml
@@ -6,54 +6,138 @@ Source Code Spelling Correction
 Usage: typos[EXE] [OPTIONS] [PATH]...
 
 Arguments:
-  [PATH]...  Paths to check (`-` to check stdin) [default: .]
+  [PATH]...
+          Paths to check (`-` to check stdin)
+          
+          [default: .]
 
 Options:
-      --file-list <FILE_LIST>  Read the list of newline separated paths from file or stdin (if `-`)
-  -j, --threads <THREADS>      The approximate number of threads to use [default: 0]
-      --sort                   Sort results
-      --force-exclude          Respect excluded files even for paths passed explicitly
-  -h, --help                   Print help
-  -V, --version                Print version
+      --file-list <FILE_LIST>
+          Read the list of newline separated paths from file or stdin (if `-`)
+
+  -j, --threads <THREADS>
+          The approximate number of threads to use
+          
+          [default: 0]
+
+      --sort
+          Sort results
+
+      --force-exclude
+          Respect excluded files even for paths passed explicitly
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 Config:
-  -c, --config <CUSTOM_CONFIG>  Custom config file
-      --isolated                Ignore implicit configuration files
-      --exclude <GLOB>          Ignore files & directories matching the glob
-      --hidden                  Search hidden files and directories
-      --no-ignore               Don't respect ignore files
-      --no-ignore-dot           Don't respect .ignore files
-      --no-ignore-global        Don't respect global ignore files
-      --no-ignore-parent        Don't respect ignore files in parent directories
-      --no-ignore-vcs           Don't respect ignore files in vcs directories
-      --binary                  Search binary files
-      --no-check-filenames      Skip verifying spelling in file names
-      --no-check-files          Skip verifying spelling in files
-      --no-unicode              Only allow ASCII characters in identifiers
-      --locale <LOCALE>         Language locale to suggest corrections for [possible values: en,
-                                en-us, en-gb, en-ca, en-au]
+  -c, --config <CUSTOM_CONFIG>
+          Custom config file
+
+      --ignore-identifiers-file <IGNORE_IDENTIFIERS_FILE>
+          Path to a file specifying identifiers which are to be ignored .
+          
+          The specified file should be UTF-8 encoded, and identifiers should be separated by
+          whitespace.
+
+      --ignore-words-file <IGNORE_WORDS_FILE>
+          Path to a file specifying words which are to be ignored.
+          
+          The specified file should be UTF-8 encoded, and identifiers should be separated by
+          whitespace.
+
+      --isolated
+          Ignore implicit configuration files
+
+      --exclude <GLOB>
+          Ignore files & directories matching the glob
+
+      --hidden
+          Search hidden files and directories
+
+      --no-ignore
+          Don't respect ignore files
+
+      --no-ignore-dot
+          Don't respect .ignore files
+
+      --no-ignore-global
+          Don't respect global ignore files
+
+      --no-ignore-parent
+          Don't respect ignore files in parent directories
+
+      --no-ignore-vcs
+          Don't respect ignore files in vcs directories
+
+      --binary
+          Search binary files
+
+      --no-check-filenames
+          Skip verifying spelling in file names
+
+      --no-check-files
+          Skip verifying spelling in files
+
+      --no-unicode
+          Only allow ASCII characters in identifiers
+
+      --locale <LOCALE>
+          Language locale to suggest corrections for
+          
+          [possible values: en, en-us, en-gb, en-ca, en-au]
 
 Mode:
-      --diff                       Print a diff of what would change
-  -w, --write-changes              Write fixes out
-      --files                      Debug: Print each file that would be spellchecked
-      --file-types                 Debug: Print each file's type
-      --highlight-identifiers      Debug: Print back out files, stylizing identifiers that would be
-                                   spellchecked
-      --identifiers                Debug: Print each identifier that would be spellchecked
-      --highlight-words            Debug: Print back out files, stylizing words that would be
-                                   spellchecked
-      --words                      Debug: Print each word that would be spellchecked
-      --dump-config <DUMP_CONFIG>  Write the current configuration to file with `-` for stdout
-      --type-list                  Show all supported file types
+      --diff
+          Print a diff of what would change
+
+  -w, --write-changes
+          Write fixes out
+
+      --files
+          Debug: Print each file that would be spellchecked
+
+      --file-types
+          Debug: Print each file's type
+
+      --highlight-identifiers
+          Debug: Print back out files, stylizing identifiers that would be spellchecked
+
+      --identifiers
+          Debug: Print each identifier that would be spellchecked
+
+      --highlight-words
+          Debug: Print back out files, stylizing words that would be spellchecked
+
+      --words
+          Debug: Print each word that would be spellchecked
+
+      --dump-config <DUMP_CONFIG>
+          Write the current configuration to file with `-` for stdout
+
+      --type-list
+          Show all supported file types
 
 Output:
-      --format <FORMAT>  Render style for messages [default: long] [possible values: silent, brief,
-                         long, json, sarif]
-      --color <WHEN>     Controls when to use color [default: auto] [possible values: auto, always,
-                         never]
-  -v, --verbose...       Increase logging verbosity
-  -q, --quiet...         Decrease logging verbosity
+      --format <FORMAT>
+          Render style for messages
+          
+          [default: long]
+          [possible values: silent, brief, long, json, sarif]
+
+      --color <WHEN>
+          Controls when to use color
+          
+          [default: auto]
+          [possible values: auto, always, never]
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
 """
 stderr = ""
 


### PR DESCRIPTION
This is an initial, very basic implementation for a solution that can hopefully close #931

Basically we just parse the given file(s) for either identifiers or words, simply broken up by _any_ white space, and use that to extend the words/identifiers, which is how I saw it done for the ignore words/identifiers from the file-specific configurations.

Currently there's no logic for considering something an invalid entry (e.g. multiple "words" per line), which I know was discussed in that issue but I'm not sure is necessary.

Just let me know if you want me to take a different approach, or if it needs refactoring etc. and I'll gladly make any changes. First time really working with this code so I'm not too familiar with it.