### PR TITLE
Enable colors for typos --help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap-verbosity-flag"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1105,7 +1115,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1401,7 +1411,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1603,6 +1613,7 @@ dependencies = [
  "assert_fs",
  "bstr",
  "clap",
+ "clap-cargo",
  "clap-verbosity-flag",
  "colorchoice-clap",
  "content_inspector",
@@ -1787,7 +1798,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/typos-cli/Cargo.toml
+++ b/crates/typos-cli/Cargo.toml
@@ -48,6 +48,7 @@ typos-vars = { version = "^0.10", path = "../typos-vars", optional = true }
 unicase = "2.8.1"
 anyhow = "1.0"
 clap = { version = "4.5.48", features = ["derive"] }
+clap-cargo = "0.18.3"
 clap-verbosity-flag = "3.0"
 ignore = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/typos-cli/src/bin/typos-cli/args.rs
+++ b/crates/typos-cli/src/bin/typos-cli/args.rs
@@ -29,6 +29,7 @@ impl Format {
 #[command(rename_all = "kebab-case")]
 #[command(about, author, version)]
 #[command(group = clap::ArgGroup::new("mode").multiple(false))]
+#[command(styles = clap_cargo::style::CLAP_STYLING)]
 pub(crate) struct Args {
     /// Paths to check (`-` to check stdin)
     #[arg(default_value = ".", group = "source")]


### PR DESCRIPTION
Based on https://github.com/astral-sh/ruff/pull/21337
Edit: Updated to usage of clap_cargo

| Before | After (style from ruff) | After (clap_cargo) |
| - | - | - |
| <img width="4406" height="3492" alt="before" src="https://github.com/user-attachments/assets/51c59a8e-1628-4d6b-88e4-00f3426d89a9" /> | <img width="4406" height="3624" alt="ruff" src="https://github.com/user-attachments/assets/730d0b25-afa5-4940-bb0d-fe8b1d6f7016" /> | <img width="4406" height="3624" alt="clap_cargo" src="https://github.com/user-attachments/assets/6f8a3ad3-d430-46e9-b360-48698248533e" /> |







