### PR TITLE
docu: bump GitHub checkout action

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -26,7 +26,7 @@
 
 See also [benchmarks](../benchsuite/runs).
 
-[JSON Lines]: http://jsonlines.org/
+[JSON Lines]: https://jsonlines.org/
 [scspell3k]: https://github.com/myint/scspell
 [misspell-go]: https://github.com/client9/misspell
 [codespell]: https://github.com/codespell-project/codespell

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Spell Check Repo
       uses: crate-ci/typos@v1.39.2
 ```
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Check spelling of file.txt
       uses: crate-ci/typos@v1.39.2


### PR DESCRIPTION
This PR bumps GitHub checkout action in the documentation to latest released version `v5`.