### PR TITLE
docs: add typos-gitlab-code-quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ extend-exclude = ["localized/*.po"]
 - [🐊Putout Processor](https://github.com/putoutjs/putout-processor-typos)
 - [Visual Studio Code](https://github.com/tekumara/typos-vscode)
 - [typos-lsp (Language Server Protocol server)](https://github.com/tekumara/typos-vscode)
+- [GitLab Code Quality](https://github.com/tahv/typos-gitlab-code-quality)
 
 #### Custom
 


### PR DESCRIPTION
Hello,

I created a small Python package to convert `typos --format json` output to [GitLab Code Quality report](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format) (inspired by #1175).

- repo: https://github.com/tahv/typos-gitlab-code-quality
- pypi: https://pypi.org/project/typos-gitlab-code-quality/