### PR TITLE
GitHub Actions annotations not showing up

### DIFF
--- a/action/format_gh.sh
+++ b/action/format_gh.sh
@@ -6,5 +6,5 @@ grep '"type":"typo"' | while IFS= read -r typo; do
   original_path="$(echo "$typo" | jq --raw-output '.path')"
   relative_path="$(realpath --relative-to="$GITHUB_WORKSPACE" "$original_path")"
   echo "$typo" | jq --arg relative_path "$relative_path" --raw-output \
-    '"::warning file=\($relative_path),line=\(.line_num),col=\(.byte_offset)::\"\(.typo)\" should be \"" + (.corrections // [] | join("\" or \"") + "\".")'
+    '"::warning file=\($relative_path),line=\(.line_num),col=\(.byte_offset + 1)::\"\(.typo)\" should be \"" + (.corrections // [] | join("\" or \"") + "\".")'
 done


### PR DESCRIPTION
The [Typos GH Action](https://github.com/crate-ci/typos/blob/master/docs/github-action.md) by default creates annotations on GitHub via [Warning Messages](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message).

However, these annotations don't show up, because of the file path: Without a `files` input parameter, the analyzed files is "." and all the found typos are relative to this path - which is correct behavior. This means, the reported paths are e.g. `./file-with-typo.txt`.
Unfortunately, GitHub doesn't seem to be able to match such a relative file path to an actual file in the PR changes. But it works, if the reported path is just `file-with-typo.txt`.

This PR changes the reported file paths to relative to GITHUB_WORKSPACE, which is the default location for the checkout action:

* Before: `::warning file=./file-with-typo.txt,line=19,col=27::"anounce" should be "announce".`
* After: `::warning file=file-with-typo.txt,line=19,col=28::"anounce" should be "announce".`

This PR also corrects another small bug - the col parameter should be 1-based.
