### PR TITLE
Bump maturin to 1.12

### DIFF
--- a/crates/typos-cli/pyproject.toml
+++ b/crates/typos-cli/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.11,<1.12"]
+requires = ["maturin>=1.12,<1.13"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Upstream fix for https://github.com/crate-ci/typos/issues/1493 should be released with this version. 