### PR TITLE
fix(cli): anchored extend-exclude patterns apply to absolute path arguments

### DIFF
--- a/crates/typos-cli/src/bin/typos-cli/main.rs
+++ b/crates/typos-cli/src/bin/typos-cli/main.rs
@@ -250,7 +250,13 @@ fn run_checks(args: &args::Args) -> proc_exit::ExitResult {
             walk.sort_by_file_name(|a, b| a.cmp(b));
         }
         if !walk_policy.extend_exclude.is_empty() {
-            let mut ignores = ignore::gitignore::GitignoreBuilder::new(".");
+            // Root the matcher at the invocation directory rather than the literal ".":
+            // candidates coming out of the walker keep the spelling of the path
+            // argument, and `Gitignore` can only strip a "." root off `./`-prefixed
+            // candidates, so for an absolute path argument anchored patterns never
+            // matched (#1075). With the CWD as the root, absolute candidates are
+            // stripped to the same relative form a relative invocation produces.
+            let mut ignores = ignore::gitignore::GitignoreBuilder::new(&global_cwd);
             for pattern in walk_policy.extend_exclude.iter() {
                 ignores
                     .add_line(None, pattern)

--- a/crates/typos-cli/tests/cli_tests.rs
+++ b/crates/typos-cli/tests/cli_tests.rs
@@ -3,3 +3,63 @@
 fn cli_tests() {
     trycmd::TestCases::new().case("tests/cmd/*.toml");
 }
+// Appended to crates/typos-cli/tests/cli_tests.rs — step 1: pin CURRENT behaviour.
+
+#[test]
+#[cfg(feature = "dict")]
+fn extend_exclude_absolute_path_argument() {
+    // `extend-exclude` patterns behave differently depending on how the *path
+    // argument* is spelled. The matcher is rooted at the literal ".", so for a
+    // relative argument the walked candidates happen to line up with the
+    // patterns, while for an absolute argument (the same directory!) anchored
+    // patterns never match and the exclusion is silently lost (#1075).
+    //
+    // This test pins the current behaviour; the fix flips the absolute case.
+    let temp = assert_fs::TempDir::new().unwrap();
+    let root = temp.path();
+
+    std::fs::write(
+        root.join("_typos.toml"),
+        "[files]\nextend-exclude = [\"/skip\"]\n",
+    )
+    .unwrap();
+    std::fs::create_dir(root.join("skip")).unwrap();
+    std::fs::write(root.join("skip").join("data.txt"), "teh quick fox\n").unwrap();
+    std::fs::write(root.join("kept.txt"), "teh quick fox\n").unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_typos");
+
+    // Relative argument: the anchored pattern applies, `skip/` is excluded.
+    let out = std::process::Command::new(bin)
+        .arg("--files")
+        .arg(".")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("kept.txt"),
+        "relative run must list kept.txt, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("data.txt"),
+        "relative run must exclude skip/, got:\n{stdout}"
+    );
+
+    // Absolute argument, same directory: the exclusion is lost today.
+    let out = std::process::Command::new(bin)
+        .arg("--files")
+        .arg(root)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("kept.txt"),
+        "absolute run must list kept.txt, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("data.txt"),
+        "absolute run currently walks into skip/ (#1075), got:\n{stdout}"
+    );
+}

--- a/crates/typos-cli/tests/cli_tests.rs
+++ b/crates/typos-cli/tests/cli_tests.rs
@@ -14,7 +14,7 @@ fn extend_exclude_absolute_path_argument() {
     // patterns, while for an absolute argument (the same directory!) anchored
     // patterns never match and the exclusion is silently lost (#1075).
     //
-    // This test pins the current behaviour; the fix flips the absolute case.
+    // Both spellings of the same directory must exclude the same files.
     let temp = assert_fs::TempDir::new().unwrap();
     let root = temp.path();
 
@@ -59,7 +59,7 @@ fn extend_exclude_absolute_path_argument() {
         "absolute run must list kept.txt, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("data.txt"),
-        "absolute run currently walks into skip/ (#1075), got:\n{stdout}"
+        !stdout.contains("data.txt"),
+        "absolute run must exclude skip/ like the relative one (#1075), got:\n{stdout}"
     );
 }


### PR DESCRIPTION
Fixes #1075.

`extend-exclude` matching is rooted at the literal `"."`:

```rust
let mut ignores = ignore::gitignore::GitignoreBuilder::new(".");
```

`Gitignore` strips the root off each candidate before matching, and a `"."` root can only strip `./`-prefixed candidates. The walker hands back entries in the same spelling as the path argument, so for `typos /abs/dir` (or `--files /abs/dir`) every candidate stays absolute, and anchored patterns like `/skip` never match anything — the exclusion is silently lost. Unanchored patterns keep working because they compile to `**/pat`, which is how this went unnoticed. Reproduced with the 1.49.0 release binaries on both Linux and Windows, identically.

The matcher is now rooted at the invocation directory:

- a relative invocation is byte-for-byte unchanged: relative candidates don't start with the root, the strip is a no-op, exactly as with `"."`;
- an absolute path argument under the CWD is stripped to the same relative form the relative invocation produces, so both spellings of the same directory exclude the same files — which is the contract asked for in the issue thread ("a passed in path should be checked against the root, regardless of format");
- an absolute argument *outside* the CWD is unchanged (nothing to strip, unanchored-only, as today). Making that case work needs an answer to "what is the root" (#593), which this PR deliberately does not touch.

Per CONTRIBUTING, the first commit adds the test pinning the current behaviour (green on the unfixed tree: relative run excludes `skip/`, absolute run of the same directory does not), and the second commit changes the behaviour and flips the assertion. `trycmd` keeps `args` as literals, so an absolute temp path can't go through `tests/cmd/*.toml`; the test uses `assert_fs` + the `CARGO_BIN_EXE_typos` binary, both already available to the suite.

Verified per commit: the new test passes on commit 1 without the fix and on commit 2 with it; `cargo fmt` clean. The full `cli_tests` suite fails 14 of 35 `trycmd` cases in my environment with formatting-only diffs (`-->` vs `╭▸`) — identical on a clean upstream checkout, so it is environmental and unrelated.

Note: this does not touch the `canonicalize` block that #1577 modifies; the change is confined to the matcher root on line 253.

AI-assisted (LLM used for drafting); the runs above are mine.
