### PR TITLE
docs: use absolute URLs for docs/ links in README (fixes #1381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Finds and corrects spelling mistakes among source code:
 - Fast enough to run on monorepos
 - Low false positives so you can run on PRs
 
-![Screenshot](./docs/screenshot.png)
+![Screenshot](https://github.com/crate-ci/typos/raw/master/docs/screenshot.png)
 
 
 [![Downloads](https://img.shields.io/github/downloads/crate-ci/typos/total.svg)](https://github.com/crate-ci/typos/releases)
@@ -23,16 +23,16 @@ Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE)
 - [Getting Started](#getting-started)
   - [False Positives](#false-positives)
   - [Integrations](#integrations)
-    - [GitHub Action](docs/github-action.md)
-    - [pre-commit](docs/pre-commit.md)
+    - [GitHub Action](https://github.com/crate-ci/typos/blob/master/docs/github-action.md)
+    - [pre-commit](https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md)
     - [Custom](#custom)
   - [Debugging](#debugging)
-- [Reference](docs/reference.md)
+- [Reference](https://github.com/crate-ci/typos/blob/master/docs/reference.md)
 - [FAQ](#faq)
-- [Comparison with other spell checkers](docs/comparison.md)
+- [Comparison with other spell checkers](https://github.com/crate-ci/typos/blob/master/docs/comparison.md)
 - [Projects using typos](https://github.com/crate-ci/typos/wiki)
 - [Benchmarks](benchsuite/runs)
-- [Design](docs/design.md)
+- [Design](https://github.com/crate-ci/typos/blob/master/docs/design.md)
 - [Contribute](CONTRIBUTING.md)
 - [CHANGELOG](CHANGELOG.md)
 
@@ -79,7 +79,7 @@ If there is any ambiguity (multiple possible corrections), `typos` will just rep
 
 Sometimes, what looks like a typo is intentional, like with people's names, acronyms, or localized content.
 
-To mark a word or an identifier (grouping of words) as valid, add it to your [`_typos.toml`](docs/reference.md) by declaring itself as the valid spelling:
+To mark a word or an identifier (grouping of words) as valid, add it to your [`_typos.toml`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) by declaring itself as the valid spelling:
 ```toml
 [default]
 extend-ignore-identifiers-re = [
@@ -95,7 +95,7 @@ AttributeIDSupressMenu = "AttributeIDSupressMenu"
 # Don't correct the surname "Teh"
 teh = "teh"
 ```
-For more ways to ignore or extend the dictionary with examples, see the [config reference](docs/reference.md).
+For more ways to ignore or extend the dictionary with examples, see the [config reference](https://github.com/crate-ci/typos/blob/master/docs/reference.md).
 
 For cases like localized content, you can disable spell checking of file contents while still checking the file name:
 ```toml
@@ -113,8 +113,8 @@ extend-exclude = ["localized/*.po"]
 
 ### Integrations
 
-- [GitHub Actions](docs/github-action.md)
-- [pre-commit](docs/pre-commit.md)
+- [GitHub Actions](https://github.com/crate-ci/typos/blob/master/docs/github-action.md)
+- [pre-commit](https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md)
 - [🐊Putout Processor](https://github.com/putoutjs/putout-processor-typos)
 - [Visual Studio Code](https://github.com/tekumara/typos-vscode)
 - [typos-lsp (Language Server Protocol server)](https://github.com/tekumara/typos-vscode)
@@ -182,7 +182,7 @@ intent by finding the closest-looking word.  It then has a gauge for when a
 word isn't close enough and assumes you know best.  The user has the
 opportunity to verify these corrections and explicitly allow or reject them.
 
-For more on the trade offs of these approaches, see [Design](docs/design.md).
+For more on the trade offs of these approaches, see [Design](https://github.com/crate-ci/typos/blob/master/docs/design.md).
 
 - To correct it locally, see also our [False Positives documentation](#false-positives).
 - To contribute your correction, see [Contribute](CONTRIBUTING.md)


### PR DESCRIPTION
Fixes #1381.

## Problem
On [crates.io](https://crates.io/crates/typos) the crate's README is rendered, but crates.io resolves relative links against the crate package directory (`crates/typos/`) rather than the repo root. The `docs/` files actually live at the repo root, so every relative `docs/*.md` link 404s on crates.io — e.g. the "config reference" link resolves to `crates/typos/docs/reference.md`, which does not exist (the file is at `docs/reference.md`).

@epage noted in the issue: *"I suspect the core issue is rust-lang/crates.io#9927. To fix this, we'll likely need to put in absolute URLs."* This PR follows that direction.

## Fix
Convert all relative `docs/*.md` markdown links in the root `README.md` to absolute GitHub URLs (against `master`), and likewise convert the screenshot image to an absolute `raw` URL. The links continue to work on GitHub and now also resolve on crates.io.

Only the link targets changed; link text and surrounding prose are untouched.

## Verification
- Confirmed `docs/reference.md` exists at repo root and `crates/typos/docs/reference.md` does not (the 404 cause).
- Confirmed each new absolute URL returns HTTP 200.
- No spelling changes to prose text; no code or other files touched.

Developed with AI assistance and reviewed by the contributor.