### PR TITLE
feat(config): support `.config/typos.toml`

### DIFF
--- a/crates/typos-cli/src/config.rs
+++ b/crates/typos-cli/src/config.rs
@@ -14,8 +14,14 @@ pub const SUPPORTED_FILE_NAMES: &[&str] = &[
     PYPROJECT_TOML,
 ];
 
+/// Config file names looked up inside [`CONFIG_DIR`], after [`SUPPORTED_FILE_NAMES`]
+///
+/// See <https://github.com/pi0/config-dir>
+const CONFIG_DIR_FILE_NAMES: &[&str] = &["typos.toml"];
+
 const CARGO_TOML: &str = "Cargo.toml";
 const PYPROJECT_TOML: &str = "pyproject.toml";
+const CONFIG_DIR: &str = ".config";
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -69,7 +75,10 @@ pub struct PyprojectTomlTool {
 
 impl Config {
     pub fn from_dir(cwd: &std::path::Path) -> Result<Option<Self>, anyhow::Error> {
-        for file in find_project_files(cwd, SUPPORTED_FILE_NAMES) {
+        let config_dir = cwd.join(CONFIG_DIR);
+        for file in find_project_files(cwd, SUPPORTED_FILE_NAMES)
+            .chain(find_project_files(&config_dir, CONFIG_DIR_FILE_NAMES))
+        {
             log::debug!("Loading {}", file.display());
             if let Some(config) = Self::from_file(&file)? {
                 return Ok(Some(config));
@@ -679,6 +688,10 @@ mod test {
             "pyproject.toml",
             "[tool.typos.files]\nextend-exclude = [\"pyproject.toml\"]\n",
         );
+        write(
+            ".config/typos.toml",
+            "[files]\nextend-exclude = [\".config/typos.toml\"]\n",
+        );
 
         // Spelled out, rather than reusing `SUPPORTED_FILE_NAMES`, so that
         // reordering the constant is caught rather than mirrored
@@ -688,6 +701,7 @@ mod test {
             ".typos.toml",
             "Cargo.toml",
             "pyproject.toml",
+            ".config/typos.toml",
         ];
 
         // Deleting the winner each time walks the full fallback order

--- a/crates/typos-cli/src/config.rs
+++ b/crates/typos-cli/src/config.rs
@@ -653,6 +653,58 @@ mod test {
     }
 
     #[test]
+    fn test_from_dir_precedence() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        let write = |name: &str, content: &str| {
+            let path = temp.path().join(name);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, content).unwrap();
+        };
+
+        // Each config excludes its own name, identifying which one got loaded
+        write("typos.toml", "[files]\nextend-exclude = [\"typos.toml\"]\n");
+        write(
+            "_typos.toml",
+            "[files]\nextend-exclude = [\"_typos.toml\"]\n",
+        );
+        write(
+            ".typos.toml",
+            "[files]\nextend-exclude = [\".typos.toml\"]\n",
+        );
+        write(
+            "Cargo.toml",
+            "[package.metadata.typos.files]\nextend-exclude = [\"Cargo.toml\"]\n",
+        );
+        write(
+            "pyproject.toml",
+            "[tool.typos.files]\nextend-exclude = [\"pyproject.toml\"]\n",
+        );
+
+        // Spelled out, rather than reusing `SUPPORTED_FILE_NAMES`, so that
+        // reordering the constant is caught rather than mirrored
+        let precedence = [
+            "typos.toml",
+            "_typos.toml",
+            ".typos.toml",
+            "Cargo.toml",
+            "pyproject.toml",
+        ];
+
+        // Deleting the winner each time walks the full fallback order
+        for expected in precedence {
+            let config = Config::from_dir(temp.path()).unwrap().unwrap();
+            assert_eq!(
+                config.files.extend_exclude,
+                [expected],
+                "expected `{expected}` to be preferred"
+            );
+            std::fs::remove_file(temp.path().join(expected)).unwrap();
+        }
+
+        assert!(Config::from_dir(temp.path()).unwrap().is_none());
+    }
+
+    #[test]
     fn test_from_defaults() {
         let null = Config::default();
         let defaulted = Config::from_defaults();

--- a/crates/typos-cli/tests/cmd/config-dir.in/.config/typos.toml
+++ b/crates/typos-cli/tests/cmd/config-dir.in/.config/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-identifiers]
+hello = ""

--- a/crates/typos-cli/tests/cmd/config-dir.in/file
+++ b/crates/typos-cli/tests/cmd/config-dir.in/file
@@ -1,0 +1,1 @@
+hello `hello`

--- a/crates/typos-cli/tests/cmd/config-dir.toml
+++ b/crates/typos-cli/tests/cmd/config-dir.toml
@@ -1,0 +1,17 @@
+bin.name = "typos"
+args = "--sort"
+status.code = 2
+stdin = ""
+stdout = """
+error: `hello` is disallowed
+  ╭▸ ./file:1:1
+  │
+1 │ hello `hello`
+  ╰╴━━━━━
+error: `hello` is disallowed
+  ╭▸ ./file:1:8
+  │
+1 │ hello `hello`
+  ╰╴       ━━━━━
+"""
+stderr = ""

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,10 +8,11 @@ Configuration is read from the following (in precedence order)
 
 - Command line arguments
 - File specified via `--config PATH`
-- Search parents of specified file / directory for one of `typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml`, or `pyproject.toml`.
+- Search parents of specified file / directory for one of `typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml`, `pyproject.toml`, or `.config/typos.toml`.
   - In `pyproject.toml`, the below fields must be under the `[tool.typos]` section. If this section does not
     exist, the config file will be skipped.
   - In `Cargo.toml`, the below fields must be under either `[workspace.metadata.typos]` or `[package.metadata.typos]`
+  - `.config/typos.toml` is only used if none of the above are found in the same directory
 
 ### Format
 


### PR DESCRIPTION
Discover configuration inside a project's `.config/` directory, tracking the emerging `.config` directory standard, which specifies `<project>/.config/<toolname>.<ext>`.  See https://github.com/pi0/config-dir.  It is looked up last, after the existing top-level names in the same directory, so existing projects are unaffected and the more discoverable locations will always be preferred. Fixes #1445 