### PR TITLE
ci: add native Windows ARM64 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest"]
         rust: ["stable"]
     continue-on-error: ${{ matrix.rust != 'stable' }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -106,7 +106,7 @@ jobs:
         mkdir -p "$staging"/doc
         cp {README.md,LICENSE-*} "$staging/"
         cp {CHANGELOG.md,docs/*} "$staging/doc/"
-        if [ "${{ matrix.os }}" = "windows-2022" ]; then
+        if [[ "${{ matrix.os }}" == windows-* ]]; then
           cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
           ls -l "$staging"
           cd "$staging"

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, linux-aarch64, macos, macos-aarch64, win-msvc]
+        build: [linux, linux-aarch64, macos, macos-aarch64, win-msvc, win-arm64-msvc]
         include:
         - build: linux
           os: ubuntu-22.04
@@ -80,6 +80,10 @@ jobs:
           os: windows-2022
           rust: stable
           target: x86_64-pc-windows-msvc
+        - build: win-arm64-msvc
+          os: windows-11-arm
+          rust: stable
+          target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary

- run regular CI on the native windows-11-arm runner
- add a win-arm64-msvc post-release artifact
- generalize Windows ZIP packaging to both Windows runners

## Validation

The full CI workflow passed in my fork, including native Windows ARM64 tests and release packaging:
https://github.com/meop/typos/actions/runs/31940827816

## Disclosure

This change was prepared with assistance from an LLM. I reviewed the resulting diff and validated it through the linked GitHub Actions run.
