### PR TITLE
ci: use the committed lockfile for releases

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -97,7 +97,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         targets: ${{ matrix.target }}
     - name: Build release binary
-      run: cargo build --target ${{ matrix.target }} --verbose --release
+      run: cargo build --locked --target ${{ matrix.target }} --verbose --release
     - name: Build archive
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

Add `--locked` to the binary release build so tagged artifacts use the dependency resolution committed with the release.

I left the ordinary test and compatibility jobs unchanged. The existing dedicated `cargo update --workspace --locked` job already enforces the repository's lockfile policy, while the unlocked workspace jobs continue exercising compatible dependency resolution as designed.

## Validation

- `cargo check --locked -p typos-cli --all-targets`
- the existing lockfile CI job remains unchanged

Prepared with assistance from OpenAI Codex; the commit includes a `Co-authored-by` trailer.