### PR TITLE
fix: allow Python asend identifier

### DIFF
--- a/crates/typos-cli/src/file_type_specifics.rs
+++ b/crates/typos-cli/src/file_type_specifics.rs
@@ -79,6 +79,7 @@ pub(crate) const TYPE_SPECIFIC_DICTS: &[(&str, StaticDictConfig)] = &[
                 "NDArray",  // numpy.typing.NDArray
                 "EOFError", // std
                 "arange",   // torch.arange, numpy.arange
+                "asend",    // AsyncGenerator.asend
                 "certifi",  // popular package
             ],
             ignore_words: &[],

--- a/crates/typos-cli/tests/cmd/false-positives.in/sample.py
+++ b/crates/typos-cli/tests/cmd/false-positives.in/sample.py
@@ -3,3 +3,7 @@ import os
 from numpy.typing import NDArray  # should work
 
 print(os.O_WRONLY)  # should work
+
+
+async def consume(generator):
+    await generator.asend(None)  # should work

--- a/crates/typos-cli/tests/cmd/false-positives.toml
+++ b/crates/typos-cli/tests/cmd/false-positives.toml
@@ -1,4 +1,11 @@
 bin.name = "typos"
 stdin = ""
-stdout = ""
+stdout = """
+error: `asend` should be `ascend`
+  ╭▸ ./sample.py:9:21
+  │
+9 │     await generator.asend(None)  # should work
+  ╰╴                    ━━━━━
+"""
 stderr = ""
+status.code = 2

--- a/crates/typos-cli/tests/cmd/false-positives.toml
+++ b/crates/typos-cli/tests/cmd/false-positives.toml
@@ -1,11 +1,4 @@
 bin.name = "typos"
 stdin = ""
-stdout = """
-error: `asend` should be `ascend`
-  ╭▸ ./sample.py:9:21
-  │
-9 │     await generator.asend(None)  # should work
-  ╰╴                    ━━━━━
-"""
+stdout = ""
 stderr = ""
-status.code = 2


### PR DESCRIPTION
## Summary

- recognize Python async generator `asend()` as a valid Python identifier
- add CLI regression coverage for a real `generator.asend(...)` call

Fixes #1607.

## Testing

- `cargo test -p typos-cli --test cli_tests`
- `cargo test -p typos-cli file_type_specifics::tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p typos-cli --all-targets -- -D warnings`
- `cargo doc -p typos-cli --no-deps`
